### PR TITLE
fix(launcher): 为 Metallum Metal 后端发布 GameSurfaceView 指针

### DIFF
--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -671,6 +671,25 @@ int launchJVM(NSString *accountId, id launchTarget, int width, int height, int m
     PUSH_MARGV_FORMAT(@"-Duser.home=%s", getenv("POJAV_HOME"));
     PUSH_MARGV_FORMAT(@"-Duser.timezone=%@", NSTimeZone.localTimeZone.name);
     PUSH_MARGV_FORMAT(@"-DUIScreen.maximumFramesPerSecond=%d", (int)UIScreen.mainScreen.maximumFramesPerSecond);
+
+    // 发布 GameSurfaceView 指针，供 Metallum Metal 后端使用
+    // +[SurfaceViewController surface] 返回静态变量 pojavWindow，该变量在
+    // -[SurfaceViewController viewDidLoad] 中被赋值（早于 launchMinecraft 派发到本后台线程）。
+    // 通过系统属性传递指针，可避免 JVM 渲染线程通过 ObjC runtime 查找 UIView 的不确定性。
+    Class surfaceVCClass = NSClassFromString(@"SurfaceViewController");
+    if (surfaceVCClass && [surfaceVCClass respondsToSelector:@selector(surface)]) {
+        id surfaceView = [surfaceVCClass performSelector:@selector(surface)];
+        if (surfaceView) {
+            PUSH_MARGV_FORMAT(@"-Dmetallum.ios.view.pointer=%p", surfaceView);
+            PUSH_MARGV_FORMAT(@"-Dmetallum.ios.screen.scale=%g", (double)UIScreen.mainScreen.scale);
+            NSLog(@"[JavaLauncher] 已发布 Metallum surface view 指针: %p (scale=%g)", surfaceView, (double)UIScreen.mainScreen.scale);
+        } else {
+            NSLog(@"[JavaLauncher] 警告：+[SurfaceViewController surface] 返回 nil，Metallum 将回退到 ObjC runtime 查找");
+        }
+    } else {
+        NSLog(@"[JavaLauncher] 警告：SurfaceViewController 类不可用，Metallum 将回退到 ObjC runtime 查找");
+    }
+
     PUSH_MARGV_LITERAL("-Dorg.lwjgl.glfw.checkThread0=false");
     PUSH_MARGV_LITERAL("-Dorg.lwjgl.system.allocator=system");
     //PUSH_MARGV_LITERAL("-Dorg.lwjgl.util.NoChecks=true");


### PR DESCRIPTION
Metallum mod 的 Metal 后端需要宿主启动器的 GameSurfaceView 指针来 附加 CAMetalLayer。此前它通过 ObjC runtime 从 JVM 渲染线程调用
+[SurfaceViewController surface] 查找 UIView，但该方式不可靠，导致：
  BackendCreationException: Could not locate the iOS surface view

当 Metallum 的 MetalBackend 失败后，Minecraft 回退到 VulkanBackend (MoltenVK)，进而崩溃在：
  -[CALayer naturalDrawableSizeMVK]: unrecognized selector sent to instance

本次修复在根源上同时解决两个问题：JVM 启动时通过 +[SurfaceViewController surface] 获取 pojavWindow（在 viewDidLoad 中赋值，早于 launchMinecraft 派发到后台线程），并将其作为 Java 系统属性 metallum.ios.view.pointer 和 metallum.ios.screen.scale 发布。Metallum 的 MetalBackend 优先读取 这两个属性，因此 Metal 后端将成功创建，VulkanBackend (MoltenVK) 不会 被触发，naturalDrawableSizeMVK 崩溃也就不会发生。