### PR TITLE
[Feature] (Renderer): Add Mithril EGL/GL bridge support

### DIFF
--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -939,6 +939,10 @@ int launchJVM(NSString *accountId, id launchTarget, int width, int height, int m
             // 其他 GL 渲染器（gl4es/ANGLE/MobileGlues）直接使用 ANGLE 的 EGL
             if (strcmp(glLibName, RENDERER_NAME_LTW) == 0) {
                 snprintf(sdlEglLib, sizeof(sdlEglLib), "@rpath/%s", RENDERER_NAME_LTW);
+            } else if (strcmp(glLibName, RENDERER_NAME_MITHRIL) == 0) {
+                // Mithril 渲染器自带完整 EGL 实现，SDL3 的 EGL 库必须指向 libmithril.dylib，
+                // 不能复用 ANGLE（否则会创建 ANGLE Metal 上下文而非 Mithril 的 Vulkan/Metal surface）。
+                snprintf(sdlEglLib, sizeof(sdlEglLib), "@rpath/%s", RENDERER_NAME_MITHRIL);
             } else {
                 snprintf(sdlEglLib, sizeof(sdlEglLib), "@rpath/%s", RENDERER_NAME_MTL_ANGLE);
             }

--- a/Natives/ctxbridges/gl_bridge.m
+++ b/Natives/ctxbridges/gl_bridge.m
@@ -23,9 +23,15 @@ static void* load_egl_symbol(void *dl_handle, const char *symbol) {
 }
 
 static bool dlsym_EGL() {
-    // MobileGL 已移除，EGL 符号始终从 ANGLE（libtinygl4angle.dylib）解析。
+    // MobileGL 已移除，EGL 符号默认从 ANGLE（libtinygl4angle.dylib）解析。
+    // Mithril 渲染器（libmithril.dylib）自带完整的 EGL 1.5 实现（Vulkan/Metal
+    // backend），必须从自身 dylib 解析 EGL 符号；若复用 ANGLE 的 EGL，会创建
+    // ANGLE Metal 上下文而非 Mithril 的 surface，且 eglChooseConfig 在 Mithril
+    // 请求的属性下可能返回 0 个配置导致 gl_init_context 断言崩溃。
     const char *renderer = getenv("AMETHYST_RENDERER");
-    const char *eglLibrary = RENDERER_NAME_MTL_ANGLE;
+    const char *eglLibrary = (renderer && strcmp(renderer, RENDERER_NAME_MITHRIL) == 0)
+        ? RENDERER_NAME_MITHRIL
+        : RENDERER_NAME_MTL_ANGLE;
     NSString *eglPath = [NSString stringWithFormat:@"@rpath/%s", eglLibrary ?: ""];
     void* dl_handle = dlopen(eglPath.UTF8String, RTLD_NOW | RTLD_GLOBAL);
     if (!dl_handle) {
@@ -118,7 +124,11 @@ gl_render_window_t* gl_init_context(gl_render_window_t *share) {
     gl_render_window_t* bundle = calloc(1, sizeof(gl_render_window_t));
 
     NSString *renderer = NSProcessInfo.processInfo.environment[@"AMETHYST_RENDERER"];
-    BOOL angleDesktopGL = [renderer isEqualToString:@ RENDERER_NAME_MTL_ANGLE];
+    // Mithril 与 ANGLE 一样实现 desktop OpenGL（Mithril 是 OpenGL 3.3 Core Profile），
+    // 因此两者都走 EGL_OPENGL_BIT + EGL_OPENGL_API 路径。Mithril 的 EGLConfig 已同时
+    // 声明 EGL_OPENGL_BIT | EGL_OPENGL_ES3_BIT，这里显式用 EGL_OPENGL_BIT 更贴合其桌面 GL 本质。
+    BOOL desktopGL = [renderer isEqualToString:@ RENDERER_NAME_MTL_ANGLE] ||
+                     [renderer isEqualToString:@ RENDERER_NAME_MITHRIL];
 
     const EGLint attribs[] = {
         EGL_RED_SIZE, 8,
@@ -127,7 +137,7 @@ gl_render_window_t* gl_init_context(gl_render_window_t *share) {
         EGL_ALPHA_SIZE, 8,
         EGL_DEPTH_SIZE, 24,
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT|EGL_PBUFFER_BIT,
-        EGL_RENDERABLE_TYPE, angleDesktopGL ? EGL_OPENGL_BIT : EGL_OPENGL_ES3_BIT,
+        EGL_RENDERABLE_TYPE, desktopGL ? EGL_OPENGL_BIT : EGL_OPENGL_ES3_BIT,
         EGL_NONE
     };
 
@@ -148,7 +158,7 @@ gl_render_window_t* gl_init_context(gl_render_window_t *share) {
     }
 
     EGLBoolean bindResult;
-    if (angleDesktopGL) {
+    if (desktopGL) {
         NSDebugLog(@"EGLBridge: Binding to desktop OpenGL");
         bindResult = handle.eglBindAPI(EGL_OPENGL_API);
     } else {

--- a/Natives/egl_bridge.m
+++ b/Natives/egl_bridge.m
@@ -140,6 +140,12 @@ int pojavInitOpenGL() {
         set_gl_bridge_tbl();
     } else if ([renderer isEqualToString:@ RENDERER_NAME_MTL_ANGLE]) {
         set_gl_bridge_tbl();
+    } else if ([renderer isEqualToString:@ RENDERER_NAME_MITHRIL]) {
+        // Mithril 渲染器：EGL + GL 全部由 libmithril.dylib 提供（Vulkan/Metal backend）。
+        // gl_bridge.m 的 dlsym_EGL() 会从 libmithril.dylib 解析 EGL 符号，
+        // gl_init_context 用 EGL_OPENGL_BIT + EGL_OPENGL_API 创建 desktop GL 3.3 上下文。
+        // 下方的统一逻辑会把它设为 LWJGL 的 opengl.libname 并 RTLD_GLOBAL 预加载。
+        set_gl_bridge_tbl();
     } else if ([renderer isEqualToString:@ RENDERER_NAME_LTW]) {
         // LTW (Large Thin Wrapper) - OpenGL Core 3.3 → OpenGL ES 3 转译层
         // 复刻自官方 MojoLauncher/LTW 仓库，完美支持 Sodium + Iris 光影。

--- a/Natives/utils.h
+++ b/Natives/utils.h
@@ -48,6 +48,11 @@
 //   - Fragment shader 编译失败时忽略错误，让 BSL/Mellow 等光影包能运行
 #define RENDERER_NAME_LTW "libltw.dylib"
 
+// Mithril 渲染器 - OpenGL 3.3 Core → Vulkan/Metal 转译层（libmithril.dylib）。
+// 提供完整的 EGL 1.5 + GL 实现（Vulkan/Metal backend），
+// 必须从其自身 dylib 解析 EGL 符号，不能复用 ANGLE 的 EGL。
+#define RENDERER_NAME_MITHRIL "libmithril.dylib"
+
 #define SPECIALBTN_KEYBOARD -1
 #define SPECIALBTN_TOGGLECTRL -2
 #define SPECIALBTN_MOUSEPRI -3


### PR DESCRIPTION
Register libmithril.dylib as a standalone renderer so the launcher routes EGL symbol resolution and GL context creation to Mithril instead of ANGLE.

Root cause: dlsym_EGL() previously resolved EGL symbols only from ANGLE (libtinygl4angle.dylib). When AMETHYST_RENDERER=libmithril.dylib, the launcher called ANGLE's eglChooseConfig against a context Mithril owns, which returned 0 matching configs and tripped the `assert(bundle->config)` crash in gl_init_context().

Changes:
- utils.h: define RENDERER_NAME_MITHRIL ("libmithril.dylib").
- gl_bridge.m: dlsym_EGL() resolves EGL from libmithril.dylib for the Mithril renderer; gl_init_context() treats Mithril like ANGLE (desktop OpenGL -> EGL_OPENGL_BIT + EGL_OPENGL_API).
- egl_bridge.m: pojavInitOpenGL() registers the Mithril renderer with set_gl_bridge_tbl() so its GL/EGL symbols are exposed to LWJGL.
- JavaLauncher.m: SDL3 EGL library points to libmithril.dylib for Mithril so SDL does not load ANGLE's EGL.

All EGL/GL/Metal translation stays inside Mithril-Wrapper; the launcher only needs to dispatch to it.