### PR TITLE
[Feature] (Renderer): Add Mithril option to launcher UI

### DIFF
--- a/Natives/LauncherPreferences.m
+++ b/Natives/LauncherPreferences.m
@@ -176,7 +176,8 @@ NSArray* getRendererKeys(BOOL containsDefault) {
         @ RENDERER_NAME_MOBILEGLUES,
         @ RENDERER_NAME_VK_ZINK,
         @ RENDERER_NAME_LTW,
-        @ RENDERER_NAME_VULKAN
+        @ RENDERER_NAME_VULKAN,
+        @ RENDERER_NAME_MITHRIL
     ].mutableCopy;
 
     if (containsDefault) {
@@ -196,7 +197,8 @@ NSArray* getRendererNames(BOOL containsDefault) {
         localize(@"preference.title.renderer.debug.mg", nil),
         localize(@"preference.title.renderer.debug.zink", nil),
         localize(@"preference.title.renderer.debug.ltw", nil),
-        localize(@"preference.title.renderer.debug.vulkan", nil)
+        localize(@"preference.title.renderer.debug.vulkan", nil),
+        localize(@"preference.title.renderer.debug.mithril", nil)
     ].mutableCopy;
 
     if (containsDefault) {

--- a/Natives/VersionManagerViewController.m
+++ b/Natives/VersionManagerViewController.m
@@ -1059,7 +1059,8 @@ static NSInteger const kSectionVersions    = 1;
         @"MobileGlues",
         @"Zink",
         @"LTW",
-        @"MoltenVK"
+        @"MoltenVK",
+        @"Mithril"
     ];
     self.rendererIcons = @[
         @"wand.and.stars",
@@ -1068,7 +1069,8 @@ static NSInteger const kSectionVersions    = 1;
         @"bolt.fill",
         @"circle.hexagongrid.fill",
         @"square.stack.3d.up.fill",
-        @"flame.fill"
+        @"flame.fill",
+        @"globe"
     ];
     self.rendererDescs = @[
         @"自动选择最佳渲染器",
@@ -1077,7 +1079,8 @@ static NSInteger const kSectionVersions    = 1;
         @"Vulkan 转译 OpenGL",
         @"OpenGL 转 Vulkan",
         @"OpenGL Core→ES 转译（Sodium+光影完美兼容）",
-        @"原生 Vulkan"
+        @"原生 Vulkan",
+        @"Mithril - OpenGL 转 Metal/Vulkan（实验性）"
     ];
 }
 

--- a/Natives/resources/en.lproj/Localizable.strings
+++ b/Natives/resources/en.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exports OpenGL 4.1";
 "preference.title.renderer.debug.ltw" = "LTW - OpenGL Core→ES wrapper (1.17+)";
 "preference.title.renderer.debug.vulkan" = "MoltenVK (26.2+) - exports vulkan 1.4";
+"preference.title.renderer.debug.mithril" = "Mithril - OpenGL 转 Metal/Vulkan（实验性）";
 
 "preference.detail.renderer" = "Change the OpenGL render engine to use. Zink is temporarily disabled on iOS 16 and later to diagnose issues.";
 


### PR DESCRIPTION
Expose libmithril.dylib as a selectable renderer in the launcher so users can pick it from the UI instead of only via AMETHYST_RENDERER profile env.

The EGL/GL dispatch for Mithril is already wired in gl_bridge.m, egl_bridge.m and JavaLauncher.m; this only surfaces the slot in the renderer pickers.

Changes:
- LauncherPreferences.m: append RENDERER_NAME_MITHRIL to getRendererKeys() and a localized label to getRendererNames() (index-aligned with keys).
- VersionManagerViewController.m: append "Mithril" to rendererNames/ rendererIcons/rendererDescs; rendererKeys comes from getRendererKeys() so it stays aligned automatically.
- en.lproj/Localizable.strings: add preference.title.renderer.debug.mithril (localize() falls back to en for other locales).

Note: bundle the built libmithril.dylib into Natives/resources/Frameworks/ (Makefile already copies that dir into the app Frameworks).