### PR TITLE
fix: make PLProfiles.profiles mutable to prevent NSConstantDictionary crash

### DIFF
--- a/Natives/PLProfiles.m
+++ b/Natives/PLProfiles.m
@@ -89,7 +89,15 @@ static PLProfiles* current;
 }
 
 - (id)profiles {
-    return self.profileDict[@"profiles"];
+    id profiles = self.profileDict[@"profiles"];
+    if (![profiles isKindOfClass:[NSDictionary class]]) {
+        profiles = [NSMutableDictionary dictionary];
+        self.profileDict[@"profiles"] = profiles;
+    } else if (![profiles isKindOfClass:[NSMutableDictionary class]]) {
+        profiles = [profiles mutableCopy];
+        self.profileDict[@"profiles"] = profiles;
+    }
+    return profiles;
 }
 
 - (id)selectedProfile {

--- a/Natives/config.h.in
+++ b/Natives/config.h.in
@@ -15,6 +15,13 @@
 #cmakedefine CONFIG_BRANCH "@CONFIG_BRANCH@"
 #cmakedefine CONFIG_COMMIT "@CONFIG_COMMIT@"
 
+#ifndef CONFIG_BRANCH
+# define CONFIG_BRANCH "unknown"
+#endif
+#ifndef CONFIG_COMMIT
+# define CONFIG_COMMIT "unknown"
+#endif
+
 #cmakedefine CONFIG_CURSEFORGE_API_KEY "@CONFIG_CURSEFORGE_API_KEY@"
 
 #ifndef CONFIG_CURSEFORGE_API_KEY 


### PR DESCRIPTION
## Problem

Launching a game can crash with:

```
[NSConstantDictionary setObject:forKeyedSubscript:]: unrecognized selector sent to instance
```

The stack reaches `-[LauncherRightPanelViewController launchGame]` at `profiles[selectedProfile] = profile;`.

## Cause

`PLProfiles.profiles` returns the nested `profiles` dictionary straight from parsed JSON. That nested dictionary can be immutable (`NSConstantDictionary`), while callers including `launchGame` mutate it directly.

## Fix

`-profiles` now lazily returns a real mutable dictionary and writes it back into `profileDict`, so existing direct mutation paths are safe.

## Test

Launch a game with an existing profile; the `lastPlayed` write and `save` no longer crash.