### PR TITLE
feat: support Stage Manager resizable game windows

### DIFF
--- a/Natives/GameMenuOverlayView.m
+++ b/Natives/GameMenuOverlayView.m
@@ -32,6 +32,9 @@ static const CGFloat kDragThreshold = 10.0;
 @property (nonatomic, assign) BOOL isDragging;
 @property (nonatomic, assign) CGPoint dragStartPoint;
 @property (nonatomic, assign) CGPoint dragStartCenter;
+// Previous overlay size used to preserve relative positions while an iPad
+// Stage Manager window is resized interactively.
+@property (nonatomic, assign) CGSize lastLayoutSize;
 
 @end
 
@@ -335,7 +338,31 @@ static const CGFloat kDragThreshold = 10.0;
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    // 屏幕旋转后重新约束位置
+
+    CGSize currentSize = self.bounds.size;
+    CGSize previousSize = self.lastLayoutSize;
+    BOOL hasPreviousSize = previousSize.width > 0.0 && previousSize.height > 0.0;
+    BOOL hasCurrentSize = currentSize.width > 0.0 && currentSize.height > 0.0;
+
+    if (hasPreviousSize
+            && hasCurrentSize
+            && !CGSizeEqualToSize(previousSize, currentSize)) {
+        // Keep the user-selected position as a percentage of the window.
+        // This preserves the floating ball and FPS label placement across
+        // continuous Stage Manager resizing instead of pinning them to an
+        // old absolute coordinate.
+        CGFloat scaleX = currentSize.width / previousSize.width;
+        CGFloat scaleY = currentSize.height / previousSize.height;
+        self.menuButton.center = CGPointMake(
+                self.menuButton.center.x * scaleX,
+                self.menuButton.center.y * scaleY);
+        self.statsLabel.center = CGPointMake(
+                self.statsLabel.center.x * scaleX,
+                self.statsLabel.center.y * scaleY);
+    }
+
+    self.lastLayoutSize = currentSize;
+    // Keep both controls visible even in the narrowest supported window.
     [self clampViewsToScreen];
 }
 

--- a/Natives/Info.plist
+++ b/Natives/Info.plist
@@ -88,7 +88,7 @@
 		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
-	<string>com.air-devs.air</string>
+	<string>com.air-devs.air1</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Natives/SceneDelegate.m
+++ b/Natives/SceneDelegate.m
@@ -121,6 +121,12 @@ extern UIWindow *mainWindow;
 #pragma mark - Orientation Support (iOS 16+)
 
 - (UIInterfaceOrientationMask)scene:(UIScene *)scene supportedInterfaceOrientationsForWindowScene:(UIWindowScene *)windowScene API_AVAILABLE(ios(16.0)) {
+    // Stage Manager can only offer its full set of resizable aspect ratios
+    // when the iPad scene accepts both portrait and landscape geometries.
+    // Keep the existing landscape-only behaviour on iPhone.
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        return UIInterfaceOrientationMaskAll;
+    }
     return UIInterfaceOrientationMaskLandscape;
 }
 

--- a/Natives/SceneDelegate.m
+++ b/Natives/SceneDelegate.m
@@ -19,14 +19,10 @@ extern UIWindow *mainWindow;
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
     UIWindowScene *windowScene = (UIWindowScene *)scene;
     
-    // 强制横屏 (iOS 16+)
-    if (@available(iOS 16.0, *)) {
-        UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] init];
-        geometryPreferences.interfaceOrientations = UIInterfaceOrientationMaskLandscape;
-        [windowScene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError *error) {
-            NSLog(@"[SceneDelegate] Failed to update geometry: %@", error);
-        }];
-    }
+    // Keep the system-provided scene geometry. Requesting a landscape-only
+    // geometry update here prevents iPadOS Stage Manager from freely resizing
+    // the window. Orientation policy remains handled by the scene delegate
+    // and Info.plist, while the window follows windowScene.coordinateSpace.
     
     self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
     self.window.frame = windowScene.coordinateSpace.bounds;

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -259,6 +259,8 @@ static GameSurfaceView* pojavWindow;
 // Last UIKit layout size propagated to the game surface. Stage Manager can
 // resize a scene without using the traditional rotation transition callback.
 @property(nonatomic) CGSize lastLayoutSize;
+// Coalesces drawable-size updates during Stage Manager interactive resizing.
+@property(nonatomic, assign) BOOL resolutionUpdateScheduled;
 
 @property(nonatomic) UIImpactFeedbackGenerator *lightHaptic;
 @property(nonatomic) UIImpactFeedbackGenerator *mediumHaptic;
@@ -1317,6 +1319,21 @@ static GameSurfaceView* pojavWindow;
 }
 
 - (void)updateSavedResolution {
+    if (self.resolutionUpdateScheduled) {
+        return;
+    }
+    self.resolutionUpdateScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.resolutionUpdateScheduled = NO;
+        [self applySavedResolution];
+    });
+}
+
+- (void)applySavedResolution {
+    if (self.surfaceView == nil) {
+        return;
+    }
+
     for (UIWindowScene *scene in UIApplication.sharedApplication.connectedScenes.allObjects) {
         self.screenScale = scene.screen.scale;
         if (scene.session.role != UIWindowSceneSessionRoleApplication) {

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -258,6 +258,9 @@ static GameSurfaceView* pojavWindow;
 @property(nonatomic) BOOL enableMouseGestures, enableHotbarGestures;
 // M1: Last UIKit surface size applied during Stage Manager resizing.
 @property(nonatomic, assign) CGSize lastSurfaceLayoutSize;
+// M2: Publish one renderer size after interactive resizing settles.
+@property(nonatomic, assign) CGSize pendingRendererLayoutSize;
+@property(nonatomic, assign) CGSize lastPublishedRendererSize;
 // Last UIKit layout size propagated to the game surface. Stage Manager can
 // resize a scene without using the traditional rotation transition callback.
 
@@ -1220,6 +1223,34 @@ static GameSurfaceView* pojavWindow;
     self.rootView.bounds = CGRectMake(0.0, 0.0, size.width + 30.0, size.height);
     self.touchView.frame = CGRectMake(0.0, 0.0, size.width, size.height);
     self.surfaceView.frame = self.touchView.bounds;
+
+    self.pendingRendererLayoutSize = size;
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(commitPendingRendererSize)
+                                               object:nil];
+    [self performSelector:@selector(commitPendingRendererSize)
+               withObject:nil
+               afterDelay:0.20
+                  inModes:@[NSRunLoopCommonModes]];
+}
+
+- (void)commitPendingRendererSize {
+    CGSize currentSize = self.view.bounds.size;
+    if (currentSize.width <= 0.0 || currentSize.height <= 0.0) {
+        return;
+    }
+
+    // If layout changed again after the timer fired, wait for the next stable tick.
+    if (!CGSizeEqualToSize(currentSize, self.pendingRendererLayoutSize)) {
+        self.pendingRendererLayoutSize = currentSize;
+        [self performSelector:@selector(commitPendingRendererSize)
+                   withObject:nil
+                   afterDelay:0.20
+                      inModes:@[NSRunLoopCommonModes]];
+        return;
+    }
+
+    [self updateSavedResolution];
 }
 
 - (void)updateAudioSettings {
@@ -1351,7 +1382,11 @@ static GameSurfaceView* pojavWindow;
     if ((windowHeight % 2) != 0) {
         --windowHeight;
     }
-    CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
+    CGSize rendererSize = CGSizeMake(windowWidth, windowHeight);
+    if (!CGSizeEqualToSize(rendererSize, self.lastPublishedRendererSize)) {
+        self.lastPublishedRendererSize = rendererSize;
+        CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
+    }
 }
 
 - (void)updateControlHiddenState:(BOOL)hide {
@@ -1744,7 +1779,6 @@ static GameSurfaceView* pojavWindow;
         [self viewWillTransitionToSize_Navigation:frame];
         self.ctrlView.frame = getSafeArea(self.view.frame);
         [self.ctrlView.subviews makeObjectsPerformSelector:@selector(update)];
-        [self updateSavedResolution];
         [GyroInput updateOrientation];
     } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         virtualMouseFrame = self.mousePointerView.frame;

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -258,8 +258,7 @@ static GameSurfaceView* pojavWindow;
 @property(nonatomic) BOOL enableMouseGestures, enableHotbarGestures;
 // Last UIKit layout size propagated to the game surface. Stage Manager can
 // resize a scene without using the traditional rotation transition callback.
-@property(nonatomic) CGSize lastLayoutSize;
-// Coalesces drawable-size updates during Stage Manager interactive resizing.
+// Coalesces preference-triggered drawable updates on the main thread.
 @property(nonatomic, assign) BOOL resolutionUpdateScheduled;
 
 @property(nonatomic) UIImpactFeedbackGenerator *lightHaptic;
@@ -1202,29 +1201,6 @@ static GameSurfaceView* pojavWindow;
     // 自动检测（startDetecting/stopDetecting）已移除，无需在此启动。
 }
 
-- (void)viewDidLayoutSubviews {
-    [super viewDidLayoutSubviews];
-
-    // Stage Manager interactive resizing may reach this layout callback
-    // without a rotation transition. Propagate only real size changes so the
-    // Metal drawable, GLFW framebuffer, touch layer and controls stay aligned
-    // without creating a layout/update loop.
-    CGSize layoutSize = self.view.bounds.size;
-    BOOL validSize = layoutSize.width > 0.0 && layoutSize.height > 0.0;
-    if (validSize
-            && self.surfaceView != nil
-            && !CGSizeEqualToSize(layoutSize, self.lastLayoutSize)) {
-        self.lastLayoutSize = layoutSize;
-        self.rootView.bounds = CGRectMake(0, 0, layoutSize.width + 30.0, layoutSize.height);
-        self.touchView.frame = self.view.bounds;
-        self.inputTextField.frame = CGRectMake(0, -32.0, layoutSize.width, 30.0);
-        self.ctrlView.frame = getSafeArea(self.view.bounds);
-        [self.ctrlView.subviews makeObjectsPerformSelector:@selector(update)];
-        [self viewWillTransitionToSize_LogView:self.view.bounds];
-        [self viewWillTransitionToSize_Navigation:self.view.bounds];
-        [self updateSavedResolution];
-    }
-
     // 更新启动遮罩层渐变背景的 frame（旋转/尺寸变化时）
     if (self.launchGradientLayer && self.launchOverlayView) {
         self.launchGradientLayer.frame = self.launchOverlayView.bounds;
@@ -1310,89 +1286,7 @@ static GameSurfaceView* pojavWindow;
     [self updateAudioSettings];
     [self updateSavedResolution];
     if (@available(iOS 16, tvOS 16, *)) {
-        if ([self.surfaceView.layer isKindOfClass:CAMetalLayer.class]) {
-            BOOL perfHUDEnabled = getPrefBool(@"video.performance_hud");
-            ((CAMetalLayer *)self.surfaceView.layer).developerHUDProperties = perfHUDEnabled ? @{@"mode": @"default"} : nil;
-        }
-    }
-    [self setNeedsUpdateOfPrefersPointerLocked];
-}
-
-- (void)updateSavedResolution {
-    if (self.resolutionUpdateScheduled) {
-        return;
-    }
-    self.resolutionUpdateScheduled = YES;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.resolutionUpdateScheduled = NO;
-        [self applySavedResolution];
-    });
-}
-
-- (void)applySavedResolution {
-    if (self.surfaceView == nil) {
-        return;
-    }
-
-    for (UIWindowScene *scene in UIApplication.sharedApplication.connectedScenes.allObjects) {
-        self.screenScale = scene.screen.scale;
-        if (scene.session.role != UIWindowSceneSessionRoleApplication) {
-            break;
-        }
-    }
-
-    if (self.surfaceView.superview != nil) {
-        // rootView intentionally reserves extra width for the control layout.
-        // The render surface must stay at the actual scene bounds or the game
-        // is rendered with a different aspect ratio than the visible window.
-        CGRect surfaceFrame = self.view.bounds;
-        surfaceFrame.origin = CGPointZero;
-        self.surfaceView.frame = surfaceFrame;
-    }
-
-    resolutionScale = getPrefFloat(@"video.resolution") / 100.0;
-    self.surfaceView.layer.contentsScale = self.screenScale * resolutionScale;
-
-    physicalWidth = roundf(self.surfaceView.frame.size.width * self.screenScale);
-    physicalHeight = roundf(self.surfaceView.frame.size.height * self.screenScale);
-    windowWidth = roundf(physicalWidth * resolutionScale);
-    windowHeight = roundf(physicalHeight * resolutionScale);
-    if ((windowWidth % 2) != 0) { --windowWidth; }
-    if ((windowHeight % 2) != 0) { --windowHeight; }
-    if ([self.surfaceView.layer isKindOfClass:CAMetalLayer.class]) {
-        CAMetalLayer *metalLayer = (CAMetalLayer *)self.surfaceView.layer;
-        metalLayer.drawableSize = CGSizeMake(MAX(windowWidth, 1), MAX(windowHeight, 1));
-        // 解锁帧率（关闭垂直同步）：三缓冲。
-        // 默认 maximumDrawableCount（通常为 2）下，当两个 drawable 都在等待呈现时，
-        // nextDrawable 会阻塞到 vblank 释放一个 drawable，间接把渲染线程锁在刷新率。
-        // 设为 3（三缓冲）后几乎总有空闲 drawable，渲染线程不再因等待 drawable 而 stall，
-        // 配合 VSync 关闭可让帧率超过屏幕刷新率。该值是 Metal 低延迟/高吞吐渲染的标准设置。
-        // 注：此优化对 GL 类渲染器（经 CAMetalLayer 呈现）最有意义；Vulkan/MoltenVK 自管 swapchain。
-        metalLayer.maximumDrawableCount = 3;
-
-        // 显式设置 presentsWithTransaction=NO（默认值）。
-        // presentsWithTransaction=YES 会导致 presentDrawable 同步等待 Core Animation 事务提交，
-        // 增加延迟且不会提高帧率。设为 NO 让 presentDrawable 异步提交到 Core Animation，
-        // 渲染线程可以立即继续下一帧渲染，配合 eglSwapInterval(0) 实现帧率解锁。
-        // 这是 Metal 高吞吐渲染的标准配置。
-        metalLayer.presentsWithTransaction = NO;
-
-        // 确保异步绘制开启（GameSurfaceView.initWithFrame 已设置，此处二次确认）
-        metalLayer.drawsAsynchronously = YES;
-
-        // 记录 Metal 层配置（仅首次），帮助诊断帧率问题
-        static BOOL s_loggedMetalConfig = NO;
-        if (!s_loggedMetalConfig) {
-            s_loggedMetalConfig = YES;
-            NSLog(@"[SurfaceVC] CAMetalLayer configured: drawableSize=%.0fx%.0f, maximumDrawableCount=%ld, presentsWithTransaction=%d, drawsAsynchronously=%d, contentsScale=%.2f",
-                  metalLayer.drawableSize.width, metalLayer.drawableSize.height,
-                  (long)metalLayer.maximumDrawableCount,
-                  metalLayer.presentsWithTransaction,
-                  metalLayer.drawsAsynchronously,
-                  metalLayer.contentsScale);
-        }
-    }
-    CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
+        CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
 }
 
 - (void)updateControlHiddenState:(BOOL)hide {
@@ -1776,7 +1670,6 @@ static GameSurfaceView* pojavWindow;
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        self.lastLayoutSize = size;
         self.rootView.bounds = CGRectMake(0, 0, size.width + 30.0, size.height);
 
         CGRect frame = self.view.frame;

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -258,8 +258,6 @@ static GameSurfaceView* pojavWindow;
 @property(nonatomic) BOOL enableMouseGestures, enableHotbarGestures;
 // Last UIKit layout size propagated to the game surface. Stage Manager can
 // resize a scene without using the traditional rotation transition callback.
-// Coalesces preference-triggered drawable updates on the main thread.
-@property(nonatomic, assign) BOOL resolutionUpdateScheduled;
 
 @property(nonatomic) UIImpactFeedbackGenerator *lightHaptic;
 @property(nonatomic) UIImpactFeedbackGenerator *mediumHaptic;
@@ -1289,17 +1287,6 @@ static GameSurfaceView* pojavWindow;
 }
 
 - (void)updateSavedResolution {
-    if (self.resolutionUpdateScheduled) {
-        return;
-    }
-    self.resolutionUpdateScheduled = YES;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.resolutionUpdateScheduled = NO;
-        [self applySavedResolution];
-    });
-}
-
-- (void)applySavedResolution {
     if (self.surfaceView == nil) {
         return;
     }
@@ -1312,10 +1299,23 @@ static GameSurfaceView* pojavWindow;
     }
 
     if (self.surfaceView.superview != nil) {
-        self.surfaceView.frame = self.surfaceView.superview.frame;
+        // Match upstream sizing, but avoid launching with a zero-sized pre-layout view.
+        CGRect surfaceFrame = self.surfaceView.superview.bounds;
+        if (surfaceFrame.size.width <= 0.0 || surfaceFrame.size.height <= 0.0) {
+            surfaceFrame = self.view.bounds;
+        }
+        if (surfaceFrame.size.width <= 0.0 || surfaceFrame.size.height <= 0.0) {
+            surfaceFrame = self.surfaceView.frame;
+        }
+        if (surfaceFrame.size.width > 0.0 && surfaceFrame.size.height > 0.0) {
+            self.surfaceView.frame = surfaceFrame;
+        }
     }
 
     resolutionScale = getPrefFloat(@"video.resolution") / 100.0;
+    if (resolutionScale <= 0.0) {
+        resolutionScale = 1.0;
+    }
     self.surfaceView.layer.contentsScale = self.screenScale * resolutionScale;
 
     physicalWidth = roundf(self.surfaceView.frame.size.width * self.screenScale);

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -1280,7 +1280,55 @@ static GameSurfaceView* pojavWindow;
     [self updateAudioSettings];
     [self updateSavedResolution];
     if (@available(iOS 16, tvOS 16, *)) {
-        CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
+        if ([self.surfaceView.layer isKindOfClass:CAMetalLayer.class]) {
+            BOOL perfHUDEnabled = getPrefBool(@"video.performance_hud");
+            ((CAMetalLayer *)self.surfaceView.layer).developerHUDProperties = perfHUDEnabled ? @{@"mode": @"default"} : nil;
+        }
+    }
+    [self setNeedsUpdateOfPrefersPointerLocked];
+}
+
+- (void)updateSavedResolution {
+    if (self.resolutionUpdateScheduled) {
+        return;
+    }
+    self.resolutionUpdateScheduled = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.resolutionUpdateScheduled = NO;
+        [self applySavedResolution];
+    });
+}
+
+- (void)applySavedResolution {
+    if (self.surfaceView == nil) {
+        return;
+    }
+
+    for (UIWindowScene *scene in UIApplication.sharedApplication.connectedScenes.allObjects) {
+        self.screenScale = scene.screen.scale;
+        if (scene.session.role != UIWindowSceneSessionRoleApplication) {
+            break;
+        }
+    }
+
+    if (self.surfaceView.superview != nil) {
+        self.surfaceView.frame = self.surfaceView.superview.frame;
+    }
+
+    resolutionScale = getPrefFloat(@"video.resolution") / 100.0;
+    self.surfaceView.layer.contentsScale = self.screenScale * resolutionScale;
+
+    physicalWidth = roundf(self.surfaceView.frame.size.width * self.screenScale);
+    physicalHeight = roundf(self.surfaceView.frame.size.height * self.screenScale);
+    windowWidth = roundf(physicalWidth * resolutionScale);
+    windowHeight = roundf(physicalHeight * resolutionScale);
+    if ((windowWidth % 2) != 0) {
+        --windowWidth;
+    }
+    if ((windowHeight % 2) != 0) {
+        --windowHeight;
+    }
+    CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
 }
 
 - (void)updateControlHiddenState:(BOOL)hide {

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -1718,7 +1718,6 @@ static GameSurfaceView* pojavWindow;
         frame.size = size;
         self.touchView.frame = frame;
         self.inputTextField.frame = CGRectMake(0, -32.0, size.width, 30.0);
-        [self viewWillTransitionToSize_LogView:frame];
         [self viewWillTransitionToSize_Navigation:frame];
         self.ctrlView.frame = getSafeArea(self.view.frame);
         [self.ctrlView.subviews makeObjectsPerformSelector:@selector(update)];

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -1201,12 +1201,6 @@ static GameSurfaceView* pojavWindow;
     // 自动检测（startDetecting/stopDetecting）已移除，无需在此启动。
 }
 
-    // 更新启动遮罩层渐变背景的 frame（旋转/尺寸变化时）
-    if (self.launchGradientLayer && self.launchOverlayView) {
-        self.launchGradientLayer.frame = self.launchOverlayView.bounds;
-    }
-}
-
 - (void)updateAudioSettings {
     NSError *sessionError = nil;
     AVAudioSessionCategory category;

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -1325,7 +1325,12 @@ static GameSurfaceView* pojavWindow;
     }
 
     if (self.surfaceView.superview != nil) {
-        self.surfaceView.frame = self.surfaceView.superview.frame;
+        // rootView intentionally reserves extra width for the control layout.
+        // The render surface must stay at the actual scene bounds or the game
+        // is rendered with a different aspect ratio than the visible window.
+        CGRect surfaceFrame = self.view.bounds;
+        surfaceFrame.origin = CGPointZero;
+        self.surfaceView.frame = surfaceFrame;
     }
 
     resolutionScale = getPrefFloat(@"video.resolution") / 100.0;

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -256,6 +256,9 @@ static GameSurfaceView* pojavWindow;
     shouldTriggerClick, shouldTriggerHaptic, slideableHotbar, toggleHidden;
 
 @property(nonatomic) BOOL enableMouseGestures, enableHotbarGestures;
+// Last UIKit layout size propagated to the game surface. Stage Manager can
+// resize a scene without using the traditional rotation transition callback.
+@property(nonatomic) CGSize lastLayoutSize;
 
 @property(nonatomic) UIImpactFeedbackGenerator *lightHaptic;
 @property(nonatomic) UIImpactFeedbackGenerator *mediumHaptic;
@@ -1199,6 +1202,27 @@ static GameSurfaceView* pojavWindow;
 
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
+
+    // Stage Manager interactive resizing may reach this layout callback
+    // without a rotation transition. Propagate only real size changes so the
+    // Metal drawable, GLFW framebuffer, touch layer and controls stay aligned
+    // without creating a layout/update loop.
+    CGSize layoutSize = self.view.bounds.size;
+    BOOL validSize = layoutSize.width > 0.0 && layoutSize.height > 0.0;
+    if (validSize
+            && self.surfaceView != nil
+            && !CGSizeEqualToSize(layoutSize, self.lastLayoutSize)) {
+        self.lastLayoutSize = layoutSize;
+        self.rootView.bounds = CGRectMake(0, 0, layoutSize.width + 30.0, layoutSize.height);
+        self.touchView.frame = self.view.bounds;
+        self.inputTextField.frame = CGRectMake(0, -32.0, layoutSize.width, 30.0);
+        self.ctrlView.frame = getSafeArea(self.view.bounds);
+        [self.ctrlView.subviews makeObjectsPerformSelector:@selector(update)];
+        [self viewWillTransitionToSize_LogView:self.view.bounds];
+        [self viewWillTransitionToSize_Navigation:self.view.bounds];
+        [self updateSavedResolution];
+    }
+
     // 更新启动遮罩层渐变背景的 frame（旋转/尺寸变化时）
     if (self.launchGradientLayer && self.launchOverlayView) {
         self.launchGradientLayer.frame = self.launchOverlayView.bounds;
@@ -1730,6 +1754,7 @@ static GameSurfaceView* pojavWindow;
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        self.lastLayoutSize = size;
         self.rootView.bounds = CGRectMake(0, 0, size.width + 30.0, size.height);
 
         CGRect frame = self.view.frame;

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -1216,6 +1216,7 @@ static GameSurfaceView* pojavWindow;
     }
 
     self.lastSurfaceLayoutSize = size;
+    NSLog(@"[StageManager][M1] UIKit layout %.0fx%.0f pt", size.width, size.height);
 
     // Keep Amethyst's +30pt root container workaround, while the visible
     // touch and game surfaces use the exact Stage Manager window bounds.
@@ -1262,6 +1263,8 @@ static GameSurfaceView* pojavWindow;
         return;
     }
 
+    NSLog(@"[StageManager][M2] Stable window %.0fx%.0f pt; publishing renderer size",
+          currentSize.width, currentSize.height);
     [self updateSavedResolution];
 }
 
@@ -1397,6 +1400,8 @@ static GameSurfaceView* pojavWindow;
     CGSize rendererSize = CGSizeMake(windowWidth, windowHeight);
     if (!CGSizeEqualToSize(rendererSize, self.lastPublishedRendererSize)) {
         self.lastPublishedRendererSize = rendererSize;
+        NSLog(@"[StageManager][M2] Renderer size %dx%d px (scale=%.2f, resolution=%.2f)",
+              windowWidth, windowHeight, self.screenScale, resolutionScale);
         CallbackBridge_nativeSendScreenSize(windowWidth, windowHeight);
     }
 }

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -256,6 +256,8 @@ static GameSurfaceView* pojavWindow;
     shouldTriggerClick, shouldTriggerHaptic, slideableHotbar, toggleHidden;
 
 @property(nonatomic) BOOL enableMouseGestures, enableHotbarGestures;
+// M1: Last UIKit surface size applied during Stage Manager resizing.
+@property(nonatomic, assign) CGSize lastSurfaceLayoutSize;
 // Last UIKit layout size propagated to the game surface. Stage Manager can
 // resize a scene without using the traditional rotation transition callback.
 
@@ -1197,6 +1199,27 @@ static GameSurfaceView* pojavWindow;
 
     // LAN 端口检测器已改为手动输入模式（LanPortDetector.h 说明），
     // 自动检测（startDetecting/stopDetecting）已移除，无需在此启动。
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+
+    CGSize size = self.view.bounds.size;
+    if (self.surfaceView == nil
+            || size.width <= 0.0
+            || size.height <= 0.0
+            || CGSizeEqualToSize(size, self.lastSurfaceLayoutSize)) {
+        return;
+    }
+
+    self.lastSurfaceLayoutSize = size;
+
+    // Keep Amethyst's +30pt root container workaround, while the visible
+    // touch and game surfaces use the exact Stage Manager window bounds.
+    self.rootView.frame = CGRectMake(0.0, 0.0, size.width + 30.0, size.height);
+    self.rootView.bounds = CGRectMake(0.0, 0.0, size.width + 30.0, size.height);
+    self.touchView.frame = CGRectMake(0.0, 0.0, size.width, size.height);
+    self.surfaceView.frame = self.touchView.bounds;
 }
 
 - (void)updateAudioSettings {

--- a/Natives/SurfaceViewController.m
+++ b/Natives/SurfaceViewController.m
@@ -1224,6 +1224,18 @@ static GameSurfaceView* pojavWindow;
     self.touchView.frame = CGRectMake(0.0, 0.0, size.width, size.height);
     self.surfaceView.frame = self.touchView.bounds;
 
+    // Keep input coordinates, safe-area controls, navigation and the floating
+    // menu aligned with the same visible bounds as the game surface.
+    self.inputTextField.frame = CGRectMake(0.0, -32.0, size.width, 30.0);
+    self.ctrlView.frame = getSafeArea(self.view.bounds);
+    [self.ctrlView.subviews makeObjectsPerformSelector:@selector(update)];
+    [self viewWillTransitionToSize_Navigation:self.view.bounds];
+
+    if (self.gameMenuOverlay != nil) {
+        self.gameMenuOverlay.frame = self.view.bounds;
+        [self.gameMenuOverlay setNeedsLayout];
+    }
+
     self.pendingRendererLayoutSize = size;
     [NSObject cancelPreviousPerformRequestsWithTarget:self
                                              selector:@selector(commitPendingRendererSize)


### PR DESCRIPTION
## What changed

- stop forcing a fixed launch window geometry on iPad
- allow portrait and landscape scene geometries for Stage Manager
- keep the UIKit game surface synchronized with interactive window resizing
- publish renderer resolution and aspect ratio after resizing settles
- keep touch controls, navigation, safe-area layout, and the floating overlay aligned
- add targeted Stage Manager resize diagnostics
- update the application bundle identifier to `com.air-devs.air1`

## Why

The game view previously stayed at its original size or stretched when the Stage Manager window changed aspect ratio. Repeated renderer-size callbacks during interactive resizing could also trigger native/JVM crashes.

## Validation

The changes were implemented as M1–M4 milestones. Each milestone passed the iOS GitHub Actions build.

Final successful build: https://github.com/twoyears666/Punch-air/actions/runs/32024456319

The runtime logs expose `[StageManager][M1]` and `[StageManager][M2]` markers for device-side verification.