### PR TITLE
fix: prevent physical keyboard JNI crash

### DIFF
--- a/Natives/input/KeyboardInput.m
+++ b/Natives/input/KeyboardInput.m
@@ -109,7 +109,10 @@ int keycodeTable[UIKeyboardHIDUsageKeyboardRightGUI+1];
     }
 
     // send the keycode
-    int keycode = keycodeTable[key.keyCode];
+    NSUInteger hidUsage = (NSUInteger)key.keyCode;
+    int keycode = hidUsage <= UIKeyboardHIDUsageKeyboardRightGUI
+        ? keycodeTable[hidUsage]
+        : 0;
     if (keycode != 0) {
         // issue #27 修复（参照 FCL commit 08c0716）：
         // MC 1.21.9+ 不再仅依赖 key 回调中的 mods 参数，而是通过

--- a/Natives/input/KeyboardInput.m
+++ b/Natives/input/KeyboardInput.m
@@ -150,7 +150,7 @@ int keycodeTable[UIKeyboardHIDUsageKeyboardRightGUI+1];
         // 关键修复 2：显式同步 MC 1.21.9+ 内部的 modifier 缓存。
         // 即便某些版本 MC 不使用 setModifiers，调用也是安全的（旧版本无此方法
         // 会直接 no-op）。这能确保物理键盘的 Shift/Ctrl/Alt 在游戏内生效。
-        CallbackBridge_syncModifiersToMC(modifiers);
+        CallbackBridge_queueModifierSync(modifiers);
     } else {
         NSLog(@"KeyboardInput: Unhandled key %lu", (unsigned long)key.keyCode);
     }

--- a/Natives/input_bridge_v3.m
+++ b/Natives/input_bridge_v3.m
@@ -283,6 +283,9 @@ void pojavPumpEvents(void* window) {
             case EVENT_TYPE_KEY:
                 if(GLFW_invoke_Key) GLFW_invoke_Key(window, event.i1, event.i2, event.i3, event.i4);
                 break;
+            case EVENT_TYPE_MODIFIERS:
+                CallbackBridge_syncModifiersToMC(event.i1);
+                break;
             case EVENT_TYPE_MOUSE_BUTTON:
                 if(GLFW_invoke_MouseButton) GLFW_invoke_MouseButton(window, event.i1, event.i2, event.i3);
                 break;
@@ -429,6 +432,13 @@ void CallbackBridge_nativeSetInputReady(BOOL inputReady) {
             GLFW_invoke_FramebufferSize((void*) showingWindow, windowWidth, windowHeight);
         }
     }
+}
+
+// Queue modifier synchronization from UIKit callbacks. JNI work is consumed
+// by pojavPumpEvents on the game thread, where runtimeJNIEnvPtr is valid.
+void CallbackBridge_queueModifierSync(int mods) {
+    if (!isInputReady) return;
+    sendData(EVENT_TYPE_MODIFIERS, mods, 0, 0, 0);
 }
 
 // ============================================================================

--- a/Natives/input_bridge_v3.m
+++ b/Natives/input_bridge_v3.m
@@ -457,8 +457,12 @@ void CallbackBridge_queueModifierSync(int mods) {
 // 也可被 Java 端 CallbackBridge.nativeSetModifiers 调用。
 // ============================================================================
 void CallbackBridge_syncModifiersToMC(int mods) {
-    JNIEnv *env = runtimeJNIEnvPtr;
-    if (!env || !isInputReady) return;
+    if (!runtimeJavaVMPtr || !isInputReady) return;
+
+    JNIEnv *env = NULL;
+    jint envStatus = (*runtimeJavaVMPtr)->GetEnv(
+        runtimeJavaVMPtr, (void **)&env, JNI_VERSION_1_4);
+    if (envStatus != JNI_OK || !env) return;
 
     jclass inputConstantsClass = (*env)->FindClass(env, "com/mojang/blaze3d/platform/InputConstants");
     if (!inputConstantsClass) {

--- a/Natives/utils.h
+++ b/Natives/utils.h
@@ -31,6 +31,7 @@
 #define EVENT_TYPE_SCROLL 1007
 #define EVENT_TYPE_WINDOW_POS 1008
 #define EVENT_TYPE_WINDOW_SIZE 1009
+#define EVENT_TYPE_MODIFIERS 1010
 
 #define GLFW_FOCUSED 0x00020001
 #define GLFW_VISIBLE 0x00020004
@@ -158,3 +159,4 @@ void CallbackBridge_pauseGameIfNeed();
 // 显式同步 MC 1.21.9+ 内部的 InputConstants modifier 缓存。
 // 由 KeyboardInput.m 在物理键盘按下/释放事件中调用。
 void CallbackBridge_syncModifiersToMC(int mods);
+void CallbackBridge_queueModifierSync(int mods);


### PR DESCRIPTION
## What changed

- Route modifier-key synchronization from UIKit keyboard callbacks through the game event queue.
- Resolve JNI environment from the current thread before invoking Java callbacks.
- Ignore HID key codes outside the supported keycode table.

## Why

The physical keyboard callback could run on an iOS thread while using a `JNIEnv*` owned by the game thread. That caused HotSpot to crash during `FindClass`/symbol-table access, especially when using the Magic Keyboard.

## Validation

- GitHub Actions build #23 passed after the queued modifier-sync path was added.
- GitHub Actions build #24 passed after removing the cross-thread JNI access.
- GitHub Actions build #25 passed after adding HID keycode bounds checking.
- Final branch is based directly on upstream `main` and is 3 commits ahead, 0 behind.

The fix is limited to:
`Natives/input/KeyboardInput.m`,
`Natives/input_bridge_v3.m`, and
`Natives/utils.h`.