### PR TITLE
fix: 修复渲染器解析、资源下载不可见与进度卡在 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ $null
 /docs
 .trae-html-share-packages/
 .trae/specs/
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,5 +152,5 @@
 3.  此项目使用 Xcode 15.4/16，iPhoneOS 17.5 SDK 构建，且最低系统支持为 iOS 14.0。
 4.  Git 提交时请使用 `herbrine8403` 用户名和 `weishixvn@outlook.com` 邮箱。
 5.  项目支持多平台构建，包括 iOS、tvOS、iOS 模拟器和 visionOS，通过 `PLATFORM` 参数指定。
-6.  渲染器设置为 Auto 时将自动选择合适的渲染器，包括 MobileGlues。
+6.  渲染器设置为 Auto 时固定解析为 ANGLE；其他渲染后端需手动明确选择。
 7.  JVM 版本将根据游戏版本自动选择 (Java 8/17/21)。

--- a/Natives/AssetVersionViewController.h
+++ b/Natives/AssetVersionViewController.h
@@ -34,6 +34,8 @@ typedef NS_ENUM(NSInteger, AssetVersionType) {
 @property (nonatomic, assign) AssetVersionType assetType;
 // 在线项目的 Modrinth/CurseForge ID
 @property (nonatomic, copy, nullable) NSString *projectID;
+// 在线 API 来源：1=Modrinth，2=CurseForge；默认 1
+@property (nonatomic, assign) NSInteger apiSource;
 // 项目显示名（用于导航栏标题）
 @property (nonatomic, copy, nullable) NSString *projectDisplayName;
 // 代理

--- a/Natives/AssetVersionViewController.m
+++ b/Natives/AssetVersionViewController.m
@@ -5,12 +5,12 @@
 //
 // 通用资源版本选择视图控制器实现
 // 阶段3统一：重构为 FCL 风格 chips 筛选条（游戏版本 + 排序方式），与 ModVersionViewController 风格一致
-// 资产类型（资源包/数据包/世界）无加载器概念，故无加载器筛选行，无双源切换（仅 Modrinth）
-// 复用 ModrinthAPI 的 getVersionsForModWithID: 方法（API 端点对所有 project_type 通用）
+// 资产类型（资源包/数据包/世界）无加载器概念，故无加载器筛选行；版本源继承搜索结果。
 //
 
 #import "AssetVersionViewController.h"
 #import "installer/modpack/ModrinthAPI.h"
+#import "installer/modpack/CurseForgeAPI.h"
 #import "ModVersion.h"
 #import "ModVersionTableViewCell.h"
 #import "AssetDetailHeaderView.h"
@@ -509,8 +509,7 @@ static NSArray<NSDictionary *> *SortOptionItems(void) {
     }
 
     [self.activityIndicator startAnimating];
-    // 复用 getVersionsForModWithID:（Modrinth /project/<id>/version 端点对所有 project_type 通用）
-    [[ModrinthAPI sharedInstance] getVersionsForModWithID:self.projectID completion:^(NSArray<ModVersion *> * _Nullable versions, NSError * _Nullable error) {
+    void (^completion)(NSArray<ModVersion *> * _Nullable, NSError * _Nullable) = ^(NSArray<ModVersion *> * _Nullable versions, NSError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self.activityIndicator stopAnimating];
             if (error) {
@@ -526,7 +525,13 @@ static NSArray<NSDictionary *> *SortOptionItems(void) {
             [self processFilters];
             [self applyFiltersAndSort];
         });
-    }];
+    };
+
+    if (self.apiSource == 2) {
+        [[CurseForgeAPI sharedInstance] getVersionsForModWithID:self.projectID completion:completion];
+    } else {
+        [[ModrinthAPI sharedInstance] getVersionsForModWithID:self.projectID completion:completion];
+    }
 }
 
 #pragma mark - 筛选 + 排序

--- a/Natives/DataPackItem.h
+++ b/Natives/DataPackItem.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // --- 在线数据包属性 ---
 @property (nonatomic, copy, nullable) NSString *onlineID;
+/// 在线 API 来源：1=Modrinth，2=CurseForge。
+@property (nonatomic, assign) NSInteger apiSource;
 @property (nonatomic, copy, nullable) NSString *author;
 @property (nonatomic, strong, nullable) NSNumber *downloads;
 @property (nonatomic, strong, nullable) NSNumber *likes;

--- a/Natives/DataPackItem.m
+++ b/Natives/DataPackItem.m
@@ -31,6 +31,7 @@
     if (self = [super init]) {
         // 来自 Modrinth 搜索结果
         _onlineID = data[@"id"] ? [data[@"id"] description] : nil;
+        _apiSource = [data[@"apiSource"] integerValue] == 2 ? 2 : 1;
         _displayName = data[@"title"] ?: @"";
         _dataPackDescription = data[@"description"] ?: @"";
         _iconURL = data[@"imageUrl"] ?: @"";

--- a/Natives/DataPackService.h
+++ b/Natives/DataPackService.h
@@ -31,7 +31,7 @@ typedef void(^DataPackDownloadProgressHandler)(NSProgress * _Nullable downloadPr
 
 // --- 本地数据包管理 ---
 // 扫描指定 profile 的 datapacks 目录，返回 .zip 和 .zip.disabled 文件列表
-- (void)scanDataPacksForProfile:(NSString *)profileName completion:(DataPackListHandler)completion;
+- (void)scanDataPacksForProfile:(NSString * _Nullable)profileName completion:(DataPackListHandler)completion;
 // 获取数据包元数据（解析 zip 内的 pack.mcmeta，获取 pack_format 和 description）
 - (void)fetchMetadataForDataPack:(DataPackItem *)item completion:(DataPackMetadataHandler)completion;
 // 启用/禁用数据包（加/去 .disabled 后缀）
@@ -44,14 +44,14 @@ typedef void(^DataPackDownloadProgressHandler)(NSProgress * _Nullable downloadPr
 // 注意：Minecraft 要求数据包放在 <gameDir>/saves/<世界名>/datapacks/，但 iOS 上无法选择世界，
 // 因此默认下载到 <gameDir>/datapacks/，需用户手动移动到对应世界目录。
 - (void)downloadDataPack:(DataPackItem *)item
-               toProfile:(NSString *)profileName
+               toProfile:(NSString * _Nullable)profileName
                 progress:(DataPackDownloadProgressHandler _Nullable)progress
               completion:(DataPackDownloadCompletionHandler _Nullable)completion;
 
 // 下载数据包到指定世界的 datapacks 目录（<gameDir>/saves/<worldName>/datapacks/）
 // worldName 为 nil 时回退到 <gameDir>/datapacks/
 - (void)downloadDataPack:(DataPackItem *)item
-               toProfile:(NSString *)profileName
+               toProfile:(NSString * _Nullable)profileName
                worldName:(nullable NSString *)worldName
                 progress:(DataPackDownloadProgressHandler _Nullable)progress
               completion:(DataPackDownloadCompletionHandler _Nullable)completion;
@@ -61,7 +61,7 @@ typedef void(^DataPackDownloadProgressHandler)(NSProgress * _Nullable downloadPr
 /// CurseForge hashes algo=1），传入即启用校验，校验失败由统一下载器按镜像/退避节奏重试；
 /// 为 nil 时不做 SHA1 校验，靠 zip EOCD 兜底校验保证完整性。
 - (void)downloadDataPack:(DataPackItem *)item
-               toProfile:(NSString *)profileName
+               toProfile:(NSString * _Nullable)profileName
                worldName:(nullable NSString *)worldName
             expectedSHA1:(nullable NSString *)expectedSHA1
                 progress:(DataPackDownloadProgressHandler _Nullable)progress
@@ -71,7 +71,7 @@ typedef void(^DataPackDownloadProgressHandler)(NSProgress * _Nullable downloadPr
 - (NSString *)iconCachePathForURL:(NSString *)urlString;
 
 /// 获取当前 profile 的 datapacks 目录，不存在时自动创建
-- (nullable NSString *)ensureDataPacksFolderForProfile:(NSString *)profileName error:(NSError **)error;
+- (nullable NSString *)ensureDataPacksFolderForProfile:(NSString * _Nullable)profileName error:(NSError **)error;
 
 @end
 

--- a/Natives/DataPackService.m
+++ b/Natives/DataPackService.m
@@ -131,84 +131,24 @@
 
 // 解析 profile 的 gameDir，返回 gameDir 或 nil
 - (nullable NSString *)gameDirForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                return gameDir;
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        return [NSString stringWithUTF8String:gameDirC];
-    }
-    return nil;
+    return [PLProfiles resolvedGameDirectoryForProfileName:profileName];
 }
 
 #pragma mark - DataPacks folder detection & scan
 
 // 查找指定 profile 的 datapacks 目录（已存在时返回路径，否则返回 nil）
 - (nullable NSString *)existingDataPacksFolderForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                NSString *dataPacksPath = [gameDir stringByAppendingPathComponent:@"datapacks"];
-                BOOL isDir = NO;
-                if ([fm fileExistsAtPath:dataPacksPath isDirectory:&isDir] && isDir) {
-                    return dataPacksPath;
-                }
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    // 回退：读取 POJAV_GAME_DIR 环境变量
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-        NSString *dataPacksPath = [gameDir stringByAppendingPathComponent:@"datapacks"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:dataPacksPath isDirectory:&isDir] && isDir) {
-            return dataPacksPath;
-        }
-    }
+    NSString *dataPacksPath = [[self gameDirForProfile:profileName] stringByAppendingPathComponent:@"datapacks"];
+    BOOL isDir = NO;
+    if ([fm fileExistsAtPath:dataPacksPath isDirectory:&isDir] && isDir) return dataPacksPath;
     return nil;
 }
 
 /// 获取当前 profile 的 datapacks 目录，不存在时自动创建
 - (nullable NSString *)ensureDataPacksFolderForProfile:(NSString *)profileName error:(NSError **)error {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *dataPacksPath = nil;
-
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                dataPacksPath = [gameDir stringByAppendingPathComponent:@"datapacks"];
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    if (!dataPacksPath) {
-        const char *gameDirC = getenv("POJAV_GAME_DIR");
-        if (gameDirC) {
-            NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-            dataPacksPath = [gameDir stringByAppendingPathComponent:@"datapacks"];
-        }
-    }
+    NSString *dataPacksPath = [[self gameDirForProfile:profileName] stringByAppendingPathComponent:@"datapacks"];
 
     if (!dataPacksPath) {
         if (error) {
@@ -457,6 +397,9 @@
                       supportsResume:YES
                              iconURL:item.iconURL];
     taskItem.downloadURL = item.selectedVersionDownloadURL;
+    NSString *taskProfileName = [PLProfiles effectiveProfileNameForPreferredName:profileName];
+    if (taskProfileName.length > 0) taskItem.userInfo[@"profileName"] = taskProfileName;
+    taskItem.userInfo[@"destinationPath"] = destinationPath;
     // redesign-download-ui Phase 3：单文件下载接入统一进度页——
     // PLTaskStagesSingleFile 单阶段 + autoPresentDetail 自动弹出 PLTaskProgressViewController
     [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId stages:PLTaskStagesSingleFile()];
@@ -464,10 +407,11 @@
 
     // retryHandler：FCL 风格重新下载，复用同一 taskItem，重新发起 PLDownloadClient 请求
     __weak typeof(self) weakSelf = self;
+    __block PLDownloadRequest *retryRequest = nil;
     taskItem.retryHandler = ^id(DownloadTaskItem *taskItemRef) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) return nil;
-        return [strongSelf restartPLDownloadForTaskId:taskItemRef.taskId];
+        if (!strongSelf || !retryRequest) return nil;
+        return [strongSelf startPLDownloadWithRequest:retryRequest taskItem:taskItemRef progress:progress completion:completion];
     };
 
     PLDownloadRequest *request = [[PLDownloadRequest alloc] init];
@@ -486,6 +430,7 @@
     request.taskIdentifier = taskItem.taskId;
     // 无 SHA1 时对 .zip 做 EOCD 兜底完整性校验
     request.allowZipFallbackCheck = YES;
+    retryRequest = request;
 
     [self startPLDownloadWithRequest:request taskItem:taskItem progress:progress completion:completion];
 
@@ -514,7 +459,6 @@
     self.downloadAccumulatedBytes[taskId] = @(0);
     self.downloadTotalBytes[taskId] = @(-1);
     self.downloadLastSpeeds[taskId] = @(0.0);
-    [self.downloadStateLock unlock];
 
     PLDownloadOperation *operation = [[PLDownloadClient sharedClient] startRequest:request
                                                                           progress:^(int64_t deltaBytes, int64_t totalExpectedBytes) {
@@ -534,12 +478,11 @@
     }];
     if (!operation) {
         // 参数错误：PLDownloadClient 会异步回调 completion（error），由统一失败路径收尾
+        [self.downloadStateLock unlock];
         return nil;
     }
 
-    [self.downloadStateLock lock];
     self.downloadOperations[taskId] = operation;
-    [self.downloadStateLock unlock];
 
     // rawTask 为 weak 引用：operation 由 PLDownloadClient 与本 Service 共同持有，
     // DownloadTaskManager 据此对 PLDownloadOperation 做 pause/resume/cancel
@@ -550,6 +493,7 @@
     [[DownloadTaskManager sharedManager] updateTaskWithId:taskId
                                               stageAtIndex:0
                                                   status:PLTaskStageStatusRunning];
+    [self.downloadStateLock unlock];
     return operation;
 }
 
@@ -642,21 +586,21 @@
     [self.downloadStateLock unlock];
 
     DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+    NSError *completionError = success ? nil : (error ?: [NSError errorWithDomain:@"DataPackServiceError" code:3 userInfo:@{NSLocalizedDescriptionKey: @"Data pack download failed."}]);
     if (success) {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
-        [manager setTaskWithId:taskId state:DownloadTaskStateCompleted];
+        [manager setTaskWithId:taskId completedWithError:nil];
     } else if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
         // 用户取消（DownloadTaskManager 已置 Cancelled，这里幂等对齐）
         [manager setTaskWithId:taskId state:DownloadTaskStateCancelled];
     } else {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-        [manager updateTaskWithId:taskId error:error];
-        [manager setTaskWithId:taskId state:DownloadTaskStateFailed];
+        [manager setTaskWithId:taskId completedWithError:completionError];
     }
 
     if (completion) {
         BOOL successFlag = success ? YES : NO;
-        NSError *capturedError = success ? nil : error;
+        NSError *capturedError = completionError;
         dispatch_async(dispatch_get_main_queue(), ^{
             completion(successFlag, capturedError);
         });

--- a/Natives/DataPacksManagerViewController.m
+++ b/Natives/DataPacksManagerViewController.m
@@ -13,6 +13,8 @@
 #import "DataPackItem.h"
 #import "ResourceCardTableViewCell.h"
 #import "DownloadViewController.h"
+#import "DownloadTaskManager.h"
+#import "PLProfiles.h"
 #import "utils.h"
 
 #pragma mark - 数据包卡片 Cell（继承 Air-Design 卡片基类，本文件内轻量子类）
@@ -91,6 +93,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.profileName = [PLProfiles effectiveProfileNameForPreferredName:self.profileName];
     // 在线下载入口已移至下载界面：固定本地模式（currentMode 等属性保留仅为兼容 .h 既有声明）
     self.currentMode = DataPacksManagerModeLocal;
     self.localItems = [NSMutableArray array];
@@ -123,6 +126,14 @@
     // 顶部提示横幅（保留既有提示文案）
     [self setupTipHeaderView];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDownloadTaskCompleted:)
+                                                 name:DownloadTaskManagerTaskCompletedNotification
+                                               object:nil];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [self refreshLocalList];
 }
 
@@ -340,6 +351,8 @@
 - (void)openDownloadPage {
     // 在线下载入口已收敛到统一下载界面（未区分资源类型 Tab，进入默认页）
     DownloadViewController *downloadVC = [[DownloadViewController alloc] init];
+    downloadVC.initialTabIndex = 4;
+    downloadVC.targetProfileName = self.profileName;
     if (self.navigationController) {
         [self.navigationController pushViewController:downloadVC animated:YES];
     } else {
@@ -348,6 +361,14 @@
         nav.modalPresentationStyle = UIModalPresentationFullScreen;
         [self presentViewController:nav animated:YES completion:nil];
     }
+}
+
+- (void)handleDownloadTaskCompleted:(NSNotification *)notification {
+    DownloadTaskItem *task = notification.userInfo[DownloadTaskManagerTaskKey];
+    if (task.state != DownloadTaskStateCompleted ||
+        ![task.resourceType isEqualToString:DownloadTaskResourceTypeDataPack] ||
+        ![task.userInfo[@"profileName"] isEqualToString:self.profileName]) return;
+    [self refreshLocalList];
 }
 
 #pragma mark - UITableView DataSource & Delegate

--- a/Natives/DownloadTaskItem.h
+++ b/Natives/DownloadTaskItem.h
@@ -34,6 +34,10 @@ extern NSString * const DownloadTaskResourceTypeModpack;
 extern NSString * const DownloadTaskResourceTypeWorld;
 extern NSString * const DownloadTaskResourceTypeJavaRuntime;
 
+/// 传输字节已完成，但任务仍在校验、落盘、解压或安装。
+/// 此阶段不应在 UI 中显示为“下载中 100%”。
+extern NSString * const DownloadTaskUserInfoTransferCompleteKey;
+
 @class DownloadTaskItem;
 
 /// 重试回调类型：业务方注册任务时设置，DownloadTaskManager.retryTaskWithId: 会调用它重建底层 rawTask。

--- a/Natives/DownloadTaskItem.m
+++ b/Natives/DownloadTaskItem.m
@@ -9,6 +9,7 @@ NSString * const DownloadTaskResourceTypeDataPack     = @"datapack";
 NSString * const DownloadTaskResourceTypeModpack      = @"modpack";
 NSString * const DownloadTaskResourceTypeWorld        = @"world";
 NSString * const DownloadTaskResourceTypeJavaRuntime  = @"javaruntime";
+NSString * const DownloadTaskUserInfoTransferCompleteKey = @"transferComplete";
 
 /// 快照取值辅助：仅接受非空 NSString，否则返回兜底值（快照内容不可信，需类型清洗）
 static NSString *PLSnapshotString(id value, NSString *fallback) {

--- a/Natives/DownloadTaskManager.m
+++ b/Natives/DownloadTaskManager.m
@@ -12,6 +12,12 @@ NSString * const DownloadTaskManagerTaskKey                             = @"Down
 /// 全局并发下载上限（同时 Downloading 的任务数）
 NSInteger const PLDownloadMaxConcurrentTasks = 3;
 
+static BOOL PLDownloadTaskStateIsTerminal(DownloadTaskState state) {
+    return state == DownloadTaskStateCompleted ||
+           state == DownloadTaskStateCancelled ||
+           state == DownloadTaskStateFailed;
+}
+
 /// NSURLSession 断点续传失效错误码（即文档中的 NSURLErrorCannotResume，
 /// iOS SDK 头文件未导出该符号，此处按系统取值本地定义）
 static NSInteger const PLNSURLErrorCannotResume = -3004;
@@ -326,11 +332,12 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     if (!rawTask) return; // rawTask 为 nil 时仅做状态层排队
 
     if ([rawTask isKindOfClass:[PLDownloadOperation class]]) {
-        if (((PLDownloadOperation *)rawTask).state == PLDownloadOperationStateRunning) {
-            [[PLDownloadClient sharedClient] pauseOperation:rawTask];
-            NSNumber *held = self.holdCounts[item.taskId];
-            self.holdCounts[item.taskId] = @((held ? held.integerValue : 0) + 1);
-        }
+        // 不在此处预读 operation.state：pauseOperation 自身会在 PLDownloadClient
+        // 的串行 stateQueue 上做幂等检查。无条件入队可保证快速出队时形成
+        // begin -> pause -> resume 的确定顺序，避免 TOCTOU 后永久停在 Paused。
+        [[PLDownloadClient sharedClient] pauseOperation:rawTask];
+        NSNumber *held = self.holdCounts[item.taskId];
+        self.holdCounts[item.taskId] = @((held ? held.integerValue : 0) + 1);
         return;
     }
 
@@ -355,10 +362,8 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     if (!rawTask) return;
 
     if ([rawTask isKindOfClass:[PLDownloadOperation class]]) {
-        PLDownloadOperation *operation = (PLDownloadOperation *)rawTask;
-        if (operation.state == PLDownloadOperationStatePaused) {
-            [[PLDownloadClient sharedClient] resumeOperation:operation];
-        }
+        // 与 pause 同一串行队列排队；不要用异步更新前的 state 做判断。
+        [[PLDownloadClient sharedClient] resumeOperation:rawTask];
         return;
     }
 
@@ -431,6 +436,10 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     if (!item) return;
 
     [self.lock lock];
+    if (PLDownloadTaskStateIsTerminal(item.state)) {
+        [self.lock unlock];
+        return;
+    }
     if (item.state == DownloadTaskStateDownloading) {
         [self.lock unlock];
         return; // 已占用槽位，幂等返回
@@ -550,6 +559,17 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
 
     id rawTask = item.rawTask;
 
+    // NSURLSessionTask 在取消式暂停的 delegate 收尾后可能已释放；rawTask 是 weak，
+    // 此时会变成 nil。业务方提供了 retryHandler 时直接重建，避免“继续”把状态
+    // 改回 Downloading 却没有任何底层任务在运行。
+    if (!rawTask && state == DownloadTaskStatePaused && item.retryHandler) {
+        [self removeFromWaitQueueLocked:taskId];
+        [self.lock unlock];
+        [self deleteResumeDataForItem:item];
+        [self retryTaskWithId:taskId];
+        return;
+    }
+
     // 底层任务已终止（此前 pause 经 cancelByProducingResumeData: 结束）：
     // resumeData 无业务方 session 归属无法直接复用 → 清除断点，回退 retryHandler 从头下载
     if ([rawTask isKindOfClass:[NSURLSessionTask class]] &&
@@ -648,6 +668,16 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     DownloadTaskItem *item = self.tasks[taskId];
     if (!item) { [self.lock unlock]; return; }
 
+    // 重试只允许从可恢复的静止状态进入。否则快速双击“重试”或自动重试与
+    // 人工重试重叠时，会同时重建多个 rawTask，较晚返回的旧任务还可能覆盖
+    // 新任务，导致后续暂停/取消控制错对象。
+    if (item.state != DownloadTaskStateFailed &&
+        item.state != DownloadTaskStateCancelled &&
+        item.state != DownloadTaskStatePaused) {
+        [self.lock unlock];
+        return;
+    }
+
     // 无 retryHandler 无法重建
     if (!item.retryHandler) {
         [self.lock unlock];
@@ -678,6 +708,7 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     item.speed = 0.0;
     item.estimatedTimeRemaining = 0.0;
     item.errorInfo = nil;
+    [item.userInfo removeObjectForKey:DownloadTaskUserInfoTransferCompleteKey];
     item.retryCount += 1;
     item.needsRecreate = NO;
 
@@ -771,7 +802,22 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     [self.lock lock];
     DownloadTaskItem *item = self.tasks[taskId];
     if (item) {
-        item.progress = progress;
+        if (PLDownloadTaskStateIsTerminal(item.state)) {
+            [self.lock unlock];
+            return; // 忽略终态之后迟到的进度回调
+        }
+        // 收到全部字节并不等于任务完成：之后还可能校验哈希、原子落盘或解压。
+        // 任务进入终态前将可见进度封顶为 99%，避免显示“下载中 100%”。
+        BOOL transferComplete = (progress >= 1.0 &&
+                                 item.state != DownloadTaskStateCompleted &&
+                                 item.state != DownloadTaskStateCancelled &&
+                                 item.state != DownloadTaskStateFailed);
+        item.progress = transferComplete ? 0.99 : progress;
+        if (transferComplete) {
+            item.userInfo[DownloadTaskUserInfoTransferCompleteKey] = @YES;
+        } else {
+            [item.userInfo removeObjectForKey:DownloadTaskUserInfoTransferCompleteKey];
+        }
         if (totalBytes >= 0) item.totalSize = totalBytes;
         item.downloadedSize = downloadedBytes;
         if (item.state == DownloadTaskStatePending && ![self isQueuedLocked:taskId]) {
@@ -801,6 +847,10 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     [self.lock lock];
     DownloadTaskItem *item = self.tasks[taskId];
     if (item) {
+        if (PLDownloadTaskStateIsTerminal(item.state)) {
+            [self.lock unlock];
+            return;
+        }
         item.speed = speed;
         item.estimatedTimeRemaining = estimatedTimeRemaining;
     }
@@ -836,6 +886,13 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
 
     DownloadTaskState oldState = item.state;
 
+    // 终态不可逆。显式重试会在 retryTaskWithId: 内先直接重置为 Pending，
+    // 因此不会被这里拦截；迟到的启动/暂停回调则不能把完成任务写回下载中。
+    if (PLDownloadTaskStateIsTerminal(oldState)) {
+        [self.lock unlock];
+        return;
+    }
+
     // 防御：manager 主动 pause/cancel（cancelByProducingResumeData / cancel）后，
     // 业务方 session delegate 会收到 NSURLErrorCancelled 并上报 Failed——此时保持 Paused/Cancelled 不被覆盖
     if (state == DownloadTaskStateFailed &&
@@ -854,6 +911,9 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     }
 
     item.state = state;
+    if (state != DownloadTaskStateDownloading) {
+        [item.userInfo removeObjectForKey:DownloadTaskUserInfoTransferCompleteKey];
+    }
     [self removeFromWaitQueueLocked:taskId];
     self.holdCounts[taskId] = nil;
 
@@ -883,6 +943,10 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     [self.lock lock];
     DownloadTaskItem *item = self.tasks[taskId];
     if (!item) { [self.lock unlock]; return; }
+    if (PLDownloadTaskStateIsTerminal(item.state)) {
+        [self.lock unlock];
+        return;
+    }
 
     // 防御：同 setTaskWithId:state:，抑制 cancelByProducingResumeData 触发的残留失败上报
     if (error &&
@@ -909,6 +973,7 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
         item.speed = 0.0;
         item.estimatedTimeRemaining = 0.0;
     }
+    [item.userInfo removeObjectForKey:DownloadTaskUserInfoTransferCompleteKey];
 
     BOOL didReleaseSlot = NO;
     if (wasDownloading) {
@@ -995,13 +1060,16 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     [self.lock lock];
     DownloadTaskItem *item = self.tasks[taskId];
     PLTaskStage *stage = [self stageForItem:item atIndex:index];
-    if (stage) stage.status = status;
+    BOOL ignoredTerminal = (stage && PLDownloadTaskStateIsTerminal(item.state) && status == PLTaskStageStatusRunning);
+    if (stage && !ignoredTerminal) {
+        stage.status = status;
+    }
     [self.lock unlock];
 
-    if (stage) {
+    if (stage && !ignoredTerminal) {
         [self postUpdateForTask:item];
         [self schedulePersistSnapshot];
-    } else if (item) {
+    } else if (item && !ignoredTerminal) {
         NSLog(@"[DownloadTaskManager] updateTaskWithId:stageAtIndex:status: invalid stage index %lu for task %@", (unsigned long)index, taskId);
     }
 }
@@ -1015,16 +1083,22 @@ static const NSTimeInterval kUIProgressNotifyThrottleInterval = 0.2;
     [self.lock lock];
     DownloadTaskItem *item = self.tasks[taskId];
     PLTaskStage *stage = [self stageForItem:item atIndex:index];
-    if (stage) {
-        stage.progress = progress;
+    BOOL ignoredTerminal = (stage && PLDownloadTaskStateIsTerminal(item.state));
+    if (stage && !ignoredTerminal) {
+        BOOL transferComplete = (progress >= 1.0 &&
+                                 stage.status == PLTaskStageStatusRunning &&
+                                 item.state != DownloadTaskStateCompleted &&
+                                 item.state != DownloadTaskStateCancelled &&
+                                 item.state != DownloadTaskStateFailed);
+        stage.progress = transferComplete ? 0.99 : progress;
         if (message) stage.message = [message copy]; // nil 表示保留原文案
     }
     [self.lock unlock];
 
-    if (stage) {
+    if (stage && !ignoredTerminal) {
         [self postProgressUpdateForTask:item];
         [self schedulePersistSnapshotForProgress];
-    } else if (item) {
+    } else if (item && !ignoredTerminal) {
         NSLog(@"[DownloadTaskManager] updateTaskWithId:stageAtIndex:progress:message: invalid stage index %lu for task %@", (unsigned long)index, taskId);
     }
 }

--- a/Natives/DownloadTasksViewController.m
+++ b/Natives/DownloadTasksViewController.m
@@ -9,6 +9,7 @@
 #import "DownloadHistoryViewController.h"
 #import "PLTaskStages.h"
 #import "PLTaskProgressViewController.h"
+#include <math.h>
 
 static NSString * const kTaskCellReuseIdentifier = @"DownloadTaskCell";
 static NSString * const kEmptyStateReuseIdentifier = @"DownloadTaskEmptyCell";
@@ -310,8 +311,11 @@ static const CGFloat kSectionInset = 16.0;
             self.progressView.hidden = NO;
             break;
         case DownloadTaskStateDownloading:
+            if ([task.userInfo[DownloadTaskUserInfoTransferCompleteKey] boolValue]) {
+                self.speedLabel.text = localize(@"i18n_str_78", nil);
+            }
             // Phase 6 Task 6.1：多文件任务显示 "42/100 · 2.1MB/s"（文件计数 + 速率）
-            if (task.totalFileCount > 0) {
+            else if (task.totalFileCount > 0) {
                 NSString *speedText = [self compactSpeedText:task.speed];
                 if (speedText.length > 0) {
                     self.speedLabel.text = [NSString
@@ -556,7 +560,10 @@ static const CGFloat kSectionInset = 16.0;
 
 - (NSString *)formattedProgress:(double)progress {
     if (progress < 0.0) return @"--";
-    return [NSString stringWithFormat:@"%.1f%%", progress * 100.0];
+    // 非终态卡片不会走本方法显示 100%；向下截断可避免 99.95% 四舍五入为 100.0%。
+    double clamped = MIN(0.999, MAX(0.0, progress));
+    double truncated = floor(clamped * 1000.0) / 10.0;
+    return [NSString stringWithFormat:@"%.1f%%", truncated];
 }
 
 - (void)configureSourceTagWithSource:(NSString *)source {

--- a/Natives/DownloadViewController.h
+++ b/Natives/DownloadViewController.h
@@ -7,4 +7,7 @@
 /// 供资源管理界面"去下载"引导跳转时定位到对应资源类型
 @property (nonatomic, assign) NSInteger initialTabIndex;
 
+/// 资源下载目标档案。由资源管理页传入；为空时回退到当前或首个有效档案。
+@property (nonatomic, copy, nullable) NSString *targetProfileName;
+
 @end

--- a/Natives/DownloadViewController.m
+++ b/Natives/DownloadViewController.m
@@ -485,10 +485,14 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
 @property (nonatomic, assign) NSInteger currentModOffset;
 @property (nonatomic, assign) NSInteger currentShaderOffset;
-@property (nonatomic, assign) BOOL isLoadingMore;
+@property (nonatomic, assign) BOOL isLoadingMods;
+@property (nonatomic, assign) BOOL isLoadingShaders;
+@property (nonatomic, assign) NSInteger modRequestGeneration;
+@property (nonatomic, assign) NSInteger shaderRequestGeneration;
 @property (nonatomic, assign) BOOL hasMoreMods;
 @property (nonatomic, assign) BOOL hasMoreShaders;
-@property (nonatomic, strong) NSString *currentSearchQuery;
+@property (nonatomic, strong) NSString *modSearchQuery;
+@property (nonatomic, strong) NSString *shaderSearchQuery;
 @property (nonatomic, strong) NSString *currentGameVersion;
 @property (nonatomic, strong) NSString *currentModLoader;
 @property (nonatomic, strong) NSString *currentSortField;
@@ -1891,15 +1895,20 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 #pragma mark - Mod Search & Loading
 
 - (void)refreshModList {
+    self.modRequestGeneration += 1;
+    self.isLoadingMods = NO;
     self.currentModOffset = 0;
     self.hasMoreMods = YES;
     [self.modList removeAllObjects];
+    [self.modTableView reloadData];
     [self loadModList];
 }
 
 - (void)loadModList {
-    if (self.isLoadingMore) return;
-    self.isLoadingMore = YES;
+    if (self.isLoadingMods) return;
+    self.isLoadingMods = YES;
+    NSInteger generation = self.modRequestGeneration;
+    NSInteger requestOffset = self.currentModOffset;
     
     if (self.currentModOffset == 0) {
         [self.loadingIndicator startAnimating];
@@ -1907,10 +1916,10 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
     
     NSMutableDictionary *filters = [NSMutableDictionary dictionary];
     filters[@"limit"] = @30;
-    filters[@"offset"] = @(self.currentModOffset);
+    filters[@"offset"] = @(requestOffset);
     
-    if (self.currentSearchQuery.length > 0) {
-        filters[@"query"] = self.currentSearchQuery;
+    if (self.modSearchQuery.length > 0) {
+        filters[@"query"] = self.modSearchQuery;
     }
     if (self.currentGameVersion.length > 0) {
         filters[@"version"] = self.currentGameVersion;
@@ -1928,23 +1937,28 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
         dispatch_async(dispatch_get_main_queue(), ^{
             __strong typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf) return;
-            [strongSelf.loadingIndicator stopAnimating];
+            if (generation != strongSelf.modRequestGeneration) return;
+            if (strongSelf.tabSegment.selectedSegmentIndex == 1) {
+                [strongSelf.loadingIndicator stopAnimating];
+            }
             [strongSelf.modTableView.refreshControl endRefreshing];
-            strongSelf.isLoadingMore = NO;
+            strongSelf.isLoadingMods = NO;
             
             if (results) {
-                if (strongSelf.currentModOffset == 0) {
+                if (requestOffset == 0) {
                     [strongSelf.modList removeAllObjects];
                 }
                 [strongSelf.modList addObjectsFromArray:results];
                 strongSelf.hasMoreMods = (results.count >= 30);
-                strongSelf.currentModOffset += results.count;
+                strongSelf.currentModOffset = requestOffset + results.count;
                 
                 [strongSelf.modTableView reloadData];
-                strongSelf.emptyLabel.hidden = (strongSelf.modList.count > 0);
-                if (strongSelf.modList.count == 0) {
-                    strongSelf.emptyLabel.text = localize(@"i18n_str_180", nil);
-                    strongSelf.emptyLabel.hidden = NO;
+                if (strongSelf.tabSegment.selectedSegmentIndex == 1) {
+                    strongSelf.emptyLabel.hidden = (strongSelf.modList.count > 0);
+                    if (strongSelf.modList.count == 0) {
+                        strongSelf.emptyLabel.text = localize(@"i18n_str_180", nil);
+                        strongSelf.emptyLabel.hidden = NO;
+                    }
                 }
             } else if (error) {
                 [strongSelf showError:error.localizedDescription];
@@ -1954,26 +1968,27 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 }
 
 - (void)searchMods:(NSString *)query {
-    self.currentSearchQuery = query;
-    self.currentModOffset = 0;
-    self.hasMoreMods = YES;
-    [self.modList removeAllObjects];
-    [self.modTableView reloadData];
-    [self loadModList];
+    self.modSearchQuery = query;
+    [self refreshModList];
 }
 
 #pragma mark - Shader Search & Loading
 
 - (void)refreshShaderList {
+    self.shaderRequestGeneration += 1;
+    self.isLoadingShaders = NO;
     self.currentShaderOffset = 0;
     self.hasMoreShaders = YES;
     [self.shaderList removeAllObjects];
+    [self.shaderTableView reloadData];
     [self loadShaderList];
 }
 
 - (void)loadShaderList {
-    if (self.isLoadingMore) return;
-    self.isLoadingMore = YES;
+    if (self.isLoadingShaders) return;
+    self.isLoadingShaders = YES;
+    NSInteger generation = self.shaderRequestGeneration;
+    NSInteger requestOffset = self.currentShaderOffset;
     
     if (self.currentShaderOffset == 0) {
         [self.loadingIndicator startAnimating];
@@ -1981,11 +1996,11 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
     
     NSMutableDictionary *filters = [NSMutableDictionary dictionary];
     filters[@"limit"] = @30;
-    filters[@"offset"] = @(self.currentShaderOffset);
+    filters[@"offset"] = @(requestOffset);
     filters[@"projectType"] = @"shader";
 
-    if (self.currentSearchQuery.length > 0) {
-        filters[@"query"] = self.currentSearchQuery;
+    if (self.shaderSearchQuery.length > 0) {
+        filters[@"query"] = self.shaderSearchQuery;
     }
     if (self.currentGameVersion.length > 0) {
         filters[@"version"] = self.currentGameVersion;
@@ -1997,23 +2012,28 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
         dispatch_async(dispatch_get_main_queue(), ^{
             __strong typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf) return;
-            [strongSelf.loadingIndicator stopAnimating];
+            if (generation != strongSelf.shaderRequestGeneration) return;
+            if (strongSelf.tabSegment.selectedSegmentIndex == 2) {
+                [strongSelf.loadingIndicator stopAnimating];
+            }
             [strongSelf.shaderTableView.refreshControl endRefreshing];
-            strongSelf.isLoadingMore = NO;
+            strongSelf.isLoadingShaders = NO;
             
             if (results) {
-                if (strongSelf.currentShaderOffset == 0) {
+                if (requestOffset == 0) {
                     [strongSelf.shaderList removeAllObjects];
                 }
                 [strongSelf.shaderList addObjectsFromArray:results];
                 strongSelf.hasMoreShaders = (results.count >= 30);
-                strongSelf.currentShaderOffset += results.count;
+                strongSelf.currentShaderOffset = requestOffset + results.count;
                 
                 [strongSelf.shaderTableView reloadData];
-                strongSelf.emptyLabel.hidden = (strongSelf.shaderList.count > 0);
-                if (strongSelf.shaderList.count == 0) {
-                    strongSelf.emptyLabel.text = localize(@"i18n_str_181", nil);
-                    strongSelf.emptyLabel.hidden = NO;
+                if (strongSelf.tabSegment.selectedSegmentIndex == 2) {
+                    strongSelf.emptyLabel.hidden = (strongSelf.shaderList.count > 0);
+                    if (strongSelf.shaderList.count == 0) {
+                        strongSelf.emptyLabel.text = localize(@"i18n_str_181", nil);
+                        strongSelf.emptyLabel.hidden = NO;
+                    }
                 }
             } else if (error) {
                 [strongSelf showError:error.localizedDescription];
@@ -2023,12 +2043,8 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 }
 
 - (void)searchShaders:(NSString *)query {
-    self.currentSearchQuery = query;
-    self.currentShaderOffset = 0;
-    self.hasMoreShaders = YES;
-    [self.shaderList removeAllObjects];
-    [self.shaderTableView reloadData];
-    [self loadShaderList];
+    self.shaderSearchQuery = query;
+    [self refreshShaderList];
 }
 
 #pragma mark - Modpack Search & Loading
@@ -2477,8 +2493,17 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
 /// 解析当前 profile 的 Minecraft 版本（用于模组下载版本预选）
 /// 复用 ModpackExportService.parseVersionId: 从 lastVersionId 反解
+- (NSString *)effectiveTargetProfileName {
+    return [PLProfiles effectiveProfileNameForPreferredName:self.targetProfileName];
+}
+
+- (NSDictionary *)effectiveTargetProfile {
+    NSString *profileName = [self effectiveTargetProfileName];
+    return profileName.length > 0 ? PLProfiles.current.profiles[profileName] : nil;
+}
+
 - (NSString *)currentProfileMinecraftVersion {
-    NSDictionary *profile = PLProfiles.current.selectedProfile;
+    NSDictionary *profile = [self effectiveTargetProfile];
     NSString *lastVersionId = profile[@"lastVersionId"];
     if (lastVersionId.length == 0) return nil;
     NSDictionary *parsed = [ModpackExportService parseVersionId:lastVersionId];
@@ -2489,7 +2514,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 /// 解析当前 profile 的模组加载器（fabric/forge/neoforge/quilt）
 /// 复用 ModpackExportService.parseVersionId: 从 lastVersionId 反解
 - (NSString *)currentProfileLoader {
-    NSDictionary *profile = PLProfiles.current.selectedProfile;
+    NSDictionary *profile = [self effectiveTargetProfile];
     NSString *lastVersionId = profile[@"lastVersionId"];
     if (lastVersionId.length == 0) return nil;
     NSDictionary *parsed = [ModpackExportService parseVersionId:lastVersionId];
@@ -2600,7 +2625,8 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
     self.currentGameVersion = nil;
     self.currentModLoader = nil;
     self.currentSortField = @"follows";
-    self.currentSearchQuery = nil;
+    self.modSearchQuery = nil;
+    self.shaderSearchQuery = nil;
     self.resourcepackSearchQuery = nil;
     self.datapackSearchQuery = nil;
     self.searchBar.text = nil;
@@ -2614,12 +2640,8 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
     UITableView *targetTable = nil;
     if (tabIndex == 1) {
         targetTable = self.modTableView;
-        self.currentModOffset = 0;
-        [self.modList removeAllObjects];
     } else if (tabIndex == 2) {
         targetTable = self.shaderTableView;
-        self.currentShaderOffset = 0;
-        [self.shaderList removeAllObjects];
     } else if (tabIndex == 3) {
         targetTable = self.resourcepackTableView;
         self.currentResourcepackOffset = 0;
@@ -2642,8 +2664,8 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
         targetTable.alpha = 0;
     } completion:^(BOOL finished) {
         switch (tabIndex) {
-            case 1: [self loadModList]; break;
-            case 2: [self loadShaderList]; break;
+            case 1: [self refreshModList]; break;
+            case 2: [self refreshShaderList]; break;
             case 3: [self loadResourcePackList]; break;
             case 4: [self loadDataPackList]; break;
             case 5: [self loadModpackList]; break;
@@ -2689,7 +2711,8 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {
     searchBar.text = nil;
-    self.currentSearchQuery = nil;
+    self.modSearchQuery = nil;
+    self.shaderSearchQuery = nil;
     self.modpackSearchQuery = nil;
     self.resourcepackSearchQuery = nil;
     self.datapackSearchQuery = nil;
@@ -4410,6 +4433,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
     ModVersionViewController *versionVC = [[ModVersionViewController alloc] init];
     versionVC.modItem = modItem;
+    versionVC.initialSource = modItem.apiSource;
     versionVC.delegate = self;
     versionVC.title = modItem.displayName;
     // FCL 风格：传入当前 profile 的偏好版本和加载器，自动选中匹配 chip 并置顶
@@ -4827,11 +4851,11 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (tableView == self.modTableView && indexPath.row == self.modList.count - 5 && self.hasMoreMods && !self.isLoadingMore) {
+    if (tableView == self.modTableView && indexPath.row == self.modList.count - 5 && self.hasMoreMods && !self.isLoadingMods) {
         [self loadModList];
     }
 
-    if (tableView == self.shaderTableView && indexPath.row == self.shaderList.count - 5 && self.hasMoreShaders && !self.isLoadingMore) {
+    if (tableView == self.shaderTableView && indexPath.row == self.shaderList.count - 5 && self.hasMoreShaders && !self.isLoadingShaders) {
         [self loadShaderList];
     }
 
@@ -4953,6 +4977,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
     ModVersionViewController *versionVC = [[ModVersionViewController alloc] init];
     versionVC.modItem = modItem;
+    versionVC.initialSource = modItem.apiSource;
     versionVC.delegate = self;
     versionVC.title = modItem.displayName;
     // FCL 风格：传入当前 profile 的偏好版本和加载器，自动选中匹配 chip 并置顶
@@ -4976,6 +5001,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
     ShaderVersionViewController *versionVC = [[ShaderVersionViewController alloc] init];
     versionVC.shaderItem = shaderItem;
+    versionVC.initialSource = shaderItem.apiSource;
     versionVC.delegate = self;
     versionVC.title = shaderItem.displayName;
     // FCL 风格：传入当前 profile 的偏好版本和加载器，自动选中匹配 chip 并置顶匹配版本
@@ -5002,6 +5028,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
     AssetVersionViewController *versionVC = [[AssetVersionViewController alloc] init];
     versionVC.assetType = AssetVersionTypeResourcePack;
+    versionVC.apiSource = item.apiSource;
     versionVC.projectID = item.onlineID;
     versionVC.projectDisplayName = item.displayName;
     versionVC.delegate = self;
@@ -5036,6 +5063,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
     AssetVersionViewController *versionVC = [[AssetVersionViewController alloc] init];
     versionVC.assetType = AssetVersionTypeDataPack;
+    versionVC.apiSource = item.apiSource;
     versionVC.projectID = item.onlineID;
     versionVC.projectDisplayName = item.displayName;
     versionVC.delegate = self;
@@ -5070,6 +5098,7 @@ typedef NS_ENUM(NSInteger, ModernAssetType) {
 
     AssetVersionViewController *versionVC = [[AssetVersionViewController alloc] init];
     versionVC.assetType = AssetVersionTypeWorld;
+    versionVC.apiSource = item.apiSource;
     versionVC.projectID = item.onlineID;
     versionVC.projectDisplayName = item.displayName;
     versionVC.delegate = self;
@@ -5177,7 +5206,7 @@ static NSString *PLSha1FromPrimaryFile(NSDictionary *primaryFile) {
 // 下载 Mod（redesign-download-ui Phase 4：进度由 Service 内部注册的下载任务 +
 // PLTaskStagesSingleFile 单阶段上报驱动统一进度页，调用方无需管理进度 UI。）
 - (void)startDownloadForModItem:(ModItem *)item {
-    NSString *profileName = PLProfiles.current.selectedProfileName ?: @"default";
+    NSString *profileName = [self effectiveTargetProfileName];
     __weak typeof(self) weakSelf = self;
     [[ModService sharedService] downloadMod:item
                                   toProfile:profileName
@@ -5200,7 +5229,7 @@ static NSString *PLSha1FromPrimaryFile(NSDictionary *primaryFile) {
 // redesign-download-ui Phase 3：进度由 Service 内部注册的下载任务 +
 // PLTaskStagesSingleFile 单阶段上报驱动统一进度页，调用方无需管理进度 UI。
 - (void)startDownloadForResourcePackItem:(ResourcePackItem *)item {
-    NSString *profileName = PLProfiles.current.selectedProfileName ?: @"default";
+    NSString *profileName = [self effectiveTargetProfileName];
     __weak typeof(self) weakSelf = self;
     [[ResourcePackService sharedService] downloadResourcePack:item
                                                     toProfile:profileName
@@ -5223,7 +5252,7 @@ static NSString *PLSha1FromPrimaryFile(NSDictionary *primaryFile) {
 // redesign-download-ui Phase 3：进度由 Service 内部注册的下载任务 +
 // PLTaskStagesSingleFile 单阶段上报驱动统一进度页，调用方无需管理进度 UI。
 - (void)startDownloadForDataPackItem:(DataPackItem *)item {
-    NSString *profileName = PLProfiles.current.selectedProfileName ?: @"default";
+    NSString *profileName = [self effectiveTargetProfileName];
     __weak typeof(self) weakSelf = self;
     [[DataPackService sharedService] downloadDataPack:item
                                             toProfile:profileName
@@ -5247,7 +5276,7 @@ static NSString *PLSha1FromPrimaryFile(NSDictionary *primaryFile) {
 // redesign-download-ui Phase 3：进度由 Service 内部注册的下载任务 +
 // PLTaskStagesSingleFile 单阶段上报驱动统一进度页，调用方无需管理进度 UI。
 - (void)startDownloadForWorldItem:(WorldItem *)item {
-    NSString *profileName = PLProfiles.current.selectedProfileName ?: @"default";
+    NSString *profileName = [self effectiveTargetProfileName];
     __weak typeof(self) weakSelf = self;
     [[WorldService sharedService] downloadWorld:item
                                         toProfile:profileName
@@ -5289,7 +5318,7 @@ static NSString *PLSha1FromPrimaryFile(NSDictionary *primaryFile) {
 // 下载光影包（redesign-download-ui Phase 4：进度由 Service 内部注册的下载任务 +
 // PLTaskStagesSingleFile 单阶段上报驱动统一进度页，调用方无需管理进度 UI。）
 - (void)startDownloadForShaderItem:(ShaderItem *)item {
-    NSString *profileName = PLProfiles.current.selectedProfileName ?: @"default";
+    NSString *profileName = [self effectiveTargetProfileName];
     __weak typeof(self) weakSelf = self;
     [[ShaderService sharedService] downloadShader:item
                                          toProfile:profileName
@@ -5479,8 +5508,7 @@ static NSString *PLSha1FromPrimaryFile(NSDictionary *primaryFile) {
     // 参考 ModService.m 的 existingModsFolderForProfile: 逻辑：
     // 1. 优先读取 profile 的 gameDir，拼接 /mods
     // 2. 若 profile 无 gameDir 或 gameDir 为 "."，回退到 $POJAV_GAME_DIR/mods
-    NSString *instanceName = PLProfiles.current.selectedProfileName;
-    if (!instanceName) instanceName = @"default";
+    NSString *instanceName = [self effectiveTargetProfileName];
 
     NSString *modsDir = nil;
 

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -156,16 +156,15 @@ void init_loadCustomEnv() {
 ///
 /// 渲染器与 MobileGlues 的关系（重要）：
 /// - MobileGlues 渲染器（libmobileglues.dylib）：直接加载 MobileGlues，config.json 生效。
-/// - Auto 渲染器：在 launchJVM 中被解析为 ANGLE（libtinygl4angle.dylib），MobileGlues 不会被加载，
-///   config.json 虽然会写入但不会被读取。用户需显式选择 MobileGlues 渲染器才能让设置生效。
+/// - Auto 渲染器：由 PLResolveRendererKey 解析为 ANGLE（libtinygl4angle.dylib），
+///   MobileGlues 不会被加载。用户需显式选择 MobileGlues 才能让这些设置生效。
 /// - Vulkan 渲染器：Vulkan 模式下 OpenGL 回退库使用 MobileGlues（对齐 Ynnyny 仓库），
 ///   config.json 会被 MobileGlues 读取并生效。
 void init_loadMobileGluesConfig() {
-    NSString *renderer = [PLProfiles resolveKeyForCurrentProfile:@"renderer"];
+    NSString *renderer = PLResolveRendererKey([PLProfiles resolveKeyForCurrentProfile:@"renderer"]);
     NSLog(@"[JavaLauncher] init_loadMobileGluesConfig: renderer=%@", renderer);
 
     BOOL usesMobileGlues = [renderer isEqualToString:@ RENDERER_NAME_MOBILEGLUES] ||
-        [renderer isEqualToString:@"auto"] ||
         [renderer isEqualToString:@ RENDERER_NAME_VULKAN];
 
     if (!usesMobileGlues) {
@@ -173,12 +172,7 @@ void init_loadMobileGluesConfig() {
         return;
     }
 
-    // 警告：auto 渲染器实际不会加载 MobileGlues，设置不会生效
-    if ([renderer isEqualToString:@"auto"]) {
-        NSLog(@"[JavaLauncher] WARNING: renderer is 'auto', will be resolved to ANGLE. "
-              @"MobileGlues settings will NOT take effect. "
-              @"Please explicitly select 'MobileGlues' renderer to use these settings.");
-    } else if ([renderer isEqualToString:@ RENDERER_NAME_VULKAN]) {
+    if ([renderer isEqualToString:@ RENDERER_NAME_VULKAN]) {
         NSLog(@"[JavaLauncher] Vulkan renderer detected, MobileGlues used as GL fallback. Config will take effect.");
     } else {
         NSLog(@"[JavaLauncher] MobileGlues renderer detected, config will take effect.");
@@ -469,8 +463,9 @@ int launchJVM(NSString *accountId, id launchTarget, int width, int height, int m
         }
 
         // Setup AMETHYST_RENDERER
-        NSString *renderer = [PLProfiles resolveKeyForCurrentProfile:@"renderer"];
-        NSLog(@"[JavaLauncher] RENDERER is set to %@\n", renderer);
+        NSString *selectedRenderer = [PLProfiles resolveKeyForCurrentProfile:@"renderer"];
+        NSString *renderer = PLResolveRendererKey(selectedRenderer);
+        NSLog(@"[JavaLauncher] RENDERER '%@' resolved to '%@'\n", selectedRenderer, renderer);
         setenv("AMETHYST_RENDERER", renderer.UTF8String, 1);
 
         // Apply Zink-specific environment variables if Zink renderer is selected
@@ -738,17 +733,6 @@ int launchJVM(NSString *accountId, id launchTarget, int width, int height, int m
     // Preset OpenGL libname
     const char *glLibName = getenv("AMETHYST_RENDERER");
     if (glLibName) {
-        if (!strcmp(glLibName, "auto")) {
-            // 关键修复（26.2 启动崩溃）：Auto 渲染器始终选 ANGLE（对齐 Ynnyny 仓库）
-            //
-            // 之前 workspace 在 Java 21+ 优先选 MobileGlues，但 Ynnyny 仓库用 ANGLE 就能正常启动 26.2。
-            // workspace 选 MobileGlues 后又缺少 init_loadMobileGluesConfig() 写 config.json，
-            // 导致 MobileGlues 用不安全默认值初始化 GL 上下文可能崩溃。现对齐 Ynnyny 始终选 ANGLE。
-            // MobileGlues 仍保留为手动选项（用户可在设置中显式选择）。
-            glLibName = RENDERER_NAME_MTL_ANGLE;
-            setenv("AMETHYST_RENDERER", glLibName, 1);
-            NSLog(@"[JavaLauncher] Auto renderer resolved to %s (always ANGLE)", glLibName);
-        }
         if (strcmp(glLibName, RENDERER_NAME_VULKAN) == 0) {
             // 对齐 Ynnyny 仓库：Vulkan 模式下 OpenGL 回退库使用 MobileGlues
             //

--- a/Natives/LauncherPreferences.h
+++ b/Natives/LauncherPreferences.h
@@ -41,3 +41,10 @@ NSString* getSelectedJavaHome(NSString* defaultJRETag, int minVersion);
 
 NSArray* getRendererKeys(BOOL containsDefault);
 NSArray* getRendererNames(BOOL containsDefault);
+
+/// 将偏好值规范化为受支持的渲染器 key；空值或旧版/损坏值回退为 "auto"。
+NSString *PLNormalizeRendererKey(id value);
+
+/// 将渲染器选择解析为本次启动实际使用的动态库。
+/// Auto 的唯一解析策略集中在这里，避免 JavaLauncher 与 EGL bridge 各自解释。
+NSString *PLResolveRendererKey(id value);

--- a/Natives/LauncherPreferences.h
+++ b/Natives/LauncherPreferences.h
@@ -42,9 +42,23 @@ NSString* getSelectedJavaHome(NSString* defaultJRETag, int minVersion);
 NSArray* getRendererKeys(BOOL containsDefault);
 NSArray* getRendererNames(BOOL containsDefault);
 
+/// Profile 选择器内部使用的“继承全局设置”稳定值。
+/// 显示时必须使用 PLProfileInheritedDisplayName()，不要直接展示或比较本地化文本。
+FOUNDATION_EXPORT NSString * const PLProfileInheritedValue;
+NSString *PLProfileInheritedDisplayName(void);
+
 /// 将偏好值规范化为受支持的渲染器 key；空值或旧版/损坏值回退为 "auto"。
 NSString *PLNormalizeRendererKey(id value);
 
 /// 将渲染器选择解析为本次启动实际使用的动态库。
 /// Auto 的唯一解析策略集中在这里，避免 JavaLauncher 与 EGL bridge 各自解释。
 NSString *PLResolveRendererKey(id value);
+
+/// MC 26.2+ Graphics API 的合法 key/本地化显示名。
+/// containsDefault=YES 时首项是“继承全局设置”，与显式 "default" 不同。
+NSArray* getGraphicsApiKeys(BOOL containsDefault);
+NSArray* getGraphicsApiNames(BOOL containsDefault);
+
+/// 将 Graphics API 偏好规范化到 default/prefer_vulkan/prefer_opengl 白名单；
+/// 空值或旧版/损坏值回退为 "default"。
+NSString *PLNormalizeGraphicsApiKey(id value);

--- a/Natives/LauncherPreferences.m
+++ b/Natives/LauncherPreferences.m
@@ -208,6 +208,12 @@ NSString* getSelectedJavaHome(NSString* defaultJRETag, int minVersion) {
 }
 
 #pragma mark Renderer
+NSString * const PLProfileInheritedValue = @"(default)";
+
+NSString *PLProfileInheritedDisplayName(void) {
+    return [NSString stringWithFormat:@"(%@)", localize(@"i18n_str_943", nil)];
+}
+
 NSArray* getRendererKeys(BOOL containsDefault) {
     NSMutableArray *array = @[
         @"auto",
@@ -220,7 +226,7 @@ NSArray* getRendererKeys(BOOL containsDefault) {
     ].mutableCopy;
 
     if (containsDefault) {
-        [array insertObject:@"(default)" atIndex:0];
+        [array insertObject:PLProfileInheritedValue atIndex:0];
     }
     
     return array;
@@ -240,7 +246,7 @@ NSArray* getRendererNames(BOOL containsDefault) {
     ].mutableCopy;
 
     if (containsDefault) {
-        [array insertObject:@"(default)" atIndex:0];
+        [array insertObject:PLProfileInheritedDisplayName() atIndex:0];
     }
 
     return array;
@@ -266,4 +272,46 @@ NSString *PLResolveRendererKey(id value) {
     // 26.2+ 在 MobileGlues 自动路径上存在上下文初始化崩溃；当前稳定策略与
     // JavaLauncher 既有行为保持一致，由 Auto 确定地选择 ANGLE。
     return [key isEqualToString:@"auto"] ? @ RENDERER_NAME_MTL_ANGLE : key;
+}
+
+#pragma mark Graphics API
+NSArray* getGraphicsApiKeys(BOOL containsDefault) {
+    NSMutableArray *array = @[
+        @"default",
+        @"prefer_vulkan",
+        @"prefer_opengl"
+    ].mutableCopy;
+
+    if (containsDefault) {
+        [array insertObject:PLProfileInheritedValue atIndex:0];
+    }
+    return array;
+}
+
+NSArray* getGraphicsApiNames(BOOL containsDefault) {
+    NSMutableArray *array = @[
+        localize(@"i18n_str_943", nil),
+        localize(@"i18n_str_941", nil),
+        localize(@"i18n_str_942", nil)
+    ].mutableCopy;
+
+    if (containsDefault) {
+        [array insertObject:PLProfileInheritedDisplayName() atIndex:0];
+    }
+    return array;
+}
+
+NSString *PLNormalizeGraphicsApiKey(id value) {
+    if (![value isKindOfClass:[NSString class]]) {
+        return @"default";
+    }
+
+    NSString *key = [(NSString *)value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (key.length == 0 || ![getGraphicsApiKeys(NO) containsObject:key]) {
+        if (key.length > 0) {
+            NSLog(@"[GraphicsAPI] Unsupported key '%@'; falling back to Default", key);
+        }
+        return @"default";
+    }
+    return key;
 }

--- a/Natives/LauncherPreferences.m
+++ b/Natives/LauncherPreferences.m
@@ -245,3 +245,25 @@ NSArray* getRendererNames(BOOL containsDefault) {
 
     return array;
 }
+
+NSString *PLNormalizeRendererKey(id value) {
+    if (![value isKindOfClass:[NSString class]]) {
+        return @"auto";
+    }
+
+    NSString *key = [(NSString *)value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (key.length == 0 || ![getRendererKeys(NO) containsObject:key]) {
+        if (key.length > 0) {
+            NSLog(@"[Renderer] Unsupported renderer key '%@'; falling back to Auto", key);
+        }
+        return @"auto";
+    }
+    return key;
+}
+
+NSString *PLResolveRendererKey(id value) {
+    NSString *key = PLNormalizeRendererKey(value);
+    // 26.2+ 在 MobileGlues 自动路径上存在上下文初始化崩溃；当前稳定策略与
+    // JavaLauncher 既有行为保持一致，由 Auto 确定地选择 ANGLE。
+    return [key isEqualToString:@"auto"] ? @ RENDERER_NAME_MTL_ANGLE : key;
+}

--- a/Natives/LauncherRightPanelViewController.m
+++ b/Natives/LauncherRightPanelViewController.m
@@ -1131,19 +1131,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
             NSDictionary *profile = PLProfiles.current.profiles[profileName];
             
             if (profile) {
-                // 应用渲染器设置
-                NSString *renderer = profile[@"renderer"] ?: @"auto";
-                if (![renderer isEqualToString:@"auto"]) {
-                    setPrefString(@"video.renderer", renderer);
-                }
-
-                // 应用图形 API 设置（MC 26.2+ 游戏内 OpenGL/Vulkan 切换）
-                // 由 JavaLauncher.m 读取并设置 AMETHYST_GRAPHICS_API 环境变量，
-                // PojavLauncher.java 写入 options.txt 的 graphicsApi 字段
-                NSString *graphicsApi = profile[@"graphicsApi"];
-                if (graphicsApi.length > 0) {
-                    setPrefString(@"video.graphics_api", graphicsApi);
-                }
+                // renderer / graphicsApi 由 JavaLauncher 直接从当前 profile 解析。
+                // 不再写回全局偏好，避免启动一个档案后污染其他继承全局设置的档案。
 
                 // 应用Java版本设置（兼容旧版直装器写入的 NSDictionary 格式）
                 id javaVerRaw = profile[@"javaVersion"];

--- a/Natives/ModItem.h
+++ b/Natives/ModItem.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // --- Properties for Online Mods ---
 @property (nonatomic, copy, nullable) NSString *onlineID;
+/// 在线 API 来源：1=Modrinth，2=CurseForge。
+@property (nonatomic, assign) NSInteger apiSource;
 @property (nonatomic, copy, nullable) NSString *author;
 @property (nonatomic, strong, nullable) NSNumber *downloads;
 @property (nonatomic, strong, nullable) NSNumber *likes;

--- a/Natives/ModItem.m
+++ b/Natives/ModItem.m
@@ -24,6 +24,7 @@
     if (self = [super init]) {
         // Data from Modrinth or CurseForge search results
         _onlineID = data[@"id"] ? [data[@"id"] description] : nil; // Ensure string
+        _apiSource = [data[@"apiSource"] integerValue] == 2 ? 2 : 1;
         _displayName = data[@"title"] ?: @"";
         _modDescription = data[@"description"] ?: @"";
         _iconURL = data[@"imageUrl"] ?: @"";

--- a/Natives/ModService.h
+++ b/Natives/ModService.h
@@ -21,17 +21,17 @@ typedef void(^ModDownloadHandler)(NSError * _Nullable error); // Added for downl
 + (instancetype)sharedService;
 
 // --- Local Mod Management ---
-- (void)scanModsForProfile:(NSString *)profileName completion:(ModListHandler)completion;
+- (void)scanModsForProfile:(NSString * _Nullable)profileName completion:(ModListHandler)completion;
 - (void)fetchMetadataForMod:(ModItem *)mod completion:(ModMetadataHandler)completion;
 - (BOOL)toggleEnableForMod:(ModItem *)mod error:(NSError **)error;
 - (BOOL)deleteMod:(ModItem *)mod error:(NSError **)error;
 
 // --- Online Mod Downloading ---
-- (void)downloadMod:(ModItem *)mod toProfile:(NSString *)profileName completion:(ModDownloadHandler)completion;
+- (void)downloadMod:(ModItem *)mod toProfile:(NSString * _Nullable)profileName completion:(ModDownloadHandler)completion;
 
 /// 下载 Mod 并上报进度
 - (void)downloadMod:(ModItem *)mod
-          toProfile:(NSString *)profileName
+          toProfile:(NSString * _Nullable)profileName
             progress:(void (^)(NSProgress *downloadProgress))progress
           completion:(ModDownloadHandler)completion;
 
@@ -40,7 +40,7 @@ typedef void(^ModDownloadHandler)(NSError * _Nullable error); // Added for downl
 /// CurseForge hashes algo=1），传入即启用校验，校验失败由统一下载器按镜像/退避节奏重试；
 /// 为 nil 时不做 SHA1 校验，靠 zip EOCD 兜底校验保证完整性。
 - (void)downloadMod:(ModItem *)mod
-          toProfile:(NSString *)profileName
+          toProfile:(NSString * _Nullable)profileName
        expectedSHA1:(nullable NSString *)expectedSHA1
            progress:(nullable void (^)(NSProgress *downloadProgress))progress
          completion:(ModDownloadHandler)completion;
@@ -49,7 +49,7 @@ typedef void(^ModDownloadHandler)(NSError * _Nullable error); // Added for downl
 - (NSString *)iconCachePathForURL:(NSString *)urlString;
 
 /// 获取当前 profile 的 mods 目录，不存在时自动创建
-- (nullable NSString *)ensureModsFolderForProfile:(NSString *)profileName error:(NSError **)error;
+- (nullable NSString *)ensureModsFolderForProfile:(NSString * _Nullable)profileName error:(NSError **)error;
 
 @end
 

--- a/Natives/ModService.m
+++ b/Natives/ModService.m
@@ -208,51 +208,26 @@
 }
 
 - (nullable NSString *)existingModsFolderForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
 
-    // 优先用 profile gameDir（已解析为绝对路径）
-    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profile];
-    if (resolvedGameDir.length > 0) {
-        NSString *modsPath = [resolvedGameDir stringByAppendingPathComponent:@"mods"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:modsPath isDirectory:&isDir] && isDir) {
-            return modsPath;
-        }
-    }
+    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profileName];
+    if (resolvedGameDir.length == 0) return nil;
 
-    // 回退到 POJAV_GAME_DIR/mods
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-        NSString *modsPath = [gameDir stringByAppendingPathComponent:@"mods"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:modsPath isDirectory:&isDir] && isDir) {
-            return modsPath;
-        }
+    NSString *modsPath = [resolvedGameDir stringByAppendingPathComponent:@"mods"];
+    BOOL isDir = NO;
+    if ([fm fileExistsAtPath:modsPath isDirectory:&isDir] && isDir) {
+        return modsPath;
     }
     return nil;
 }
 
 /// 获取当前 profile 的 mods 目录，不存在时自动创建
 - (nullable NSString *)ensureModsFolderForProfile:(NSString *)profileName error:(NSError **)error {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *modsPath = nil;
-
-    // 优先用 profile gameDir（已解析为绝对路径）
-    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profile];
-    if (resolvedGameDir.length > 0) {
-        modsPath = [resolvedGameDir stringByAppendingPathComponent:@"mods"];
-    }
-
-    if (!modsPath) {
-        const char *gameDirC = getenv("POJAV_GAME_DIR");
-        if (gameDirC) {
-            NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-            modsPath = [gameDir stringByAppendingPathComponent:@"mods"];
-        }
-    }
+    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profileName];
+    NSString *modsPath = resolvedGameDir.length > 0
+        ? [resolvedGameDir stringByAppendingPathComponent:@"mods"]
+        : nil;
 
     if (!modsPath) {
         if (error) {

--- a/Natives/ModService.m
+++ b/Natives/ModService.m
@@ -204,30 +204,7 @@
 /// 之前直接使用相对路径会导致 mods 文件夹找不到（fileExistsAtPath 对相对路径基于 cwd 解析，
 /// 而 cwd 不一定是 POJAV_GAME_DIR）。
 - (nullable NSString *)resolveAbsoluteGameDirForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if (![prof isKindOfClass:[NSDictionary class]]) return nil;
-        NSString *gameDir = prof[@"gameDir"];
-        if (![gameDir isKindOfClass:[NSString class]] || gameDir.length == 0) return nil;
-        if ([gameDir isEqualToString:@"."]) {
-            // "." 表示主目录
-            const char *env = getenv("POJAV_GAME_DIR");
-            return env ? [NSString stringWithUTF8String:env] : NSHomeDirectory();
-        }
-        if ([gameDir isAbsolutePath]) {
-            return gameDir;
-        }
-        // 相对路径，相对于 POJAV_GAME_DIR 解析
-        const char *env = getenv("POJAV_GAME_DIR");
-        NSString *baseDir = env ? [NSString stringWithUTF8String:env] : NSHomeDirectory();
-        // 去掉 "./" 前缀（如果有），stringByAppendingPathComponent 能正确处理
-        NSString *cleanGameDir = [gameDir hasPrefix:@"./"] ? [gameDir substringFromIndex:2] : gameDir;
-        return [baseDir stringByAppendingPathComponent:cleanGameDir];
-    } @catch (NSException *ex) {
-        return nil;
-    }
+    return [PLProfiles resolvedGameDirectoryForProfileName:profileName];
 }
 
 - (nullable NSString *)existingModsFolderForProfile:(NSString *)profileName {
@@ -532,10 +509,11 @@
        expectedSHA1:(nullable NSString *)expectedSHA1
            progress:(nullable void (^)(NSProgress *downloadProgress))progress
          completion:(ModDownloadHandler)completion {
-    NSString *modsFolder = [self existingModsFolderForProfile:profileName];
+    NSError *folderError = nil;
+    NSString *modsFolder = [self ensureModsFolderForProfile:profileName error:&folderError];
     if (!modsFolder) {
         if (completion) {
-            NSError *error = [NSError errorWithDomain:@"ModServiceError" code:1 userInfo:@{NSLocalizedDescriptionKey:localize(@"i18n_str_453", nil)}];
+            NSError *error = folderError ?: [NSError errorWithDomain:@"ModServiceError" code:1 userInfo:@{NSLocalizedDescriptionKey:localize(@"i18n_str_453", nil)}];
             dispatch_async(dispatch_get_main_queue(), ^{ completion(error); });
         }
         return;
@@ -565,6 +543,9 @@
                       supportsResume:YES
                              iconURL:mod.iconURL];
     taskItem.downloadURL = mod.selectedVersionDownloadURL;
+    NSString *taskProfileName = [PLProfiles effectiveProfileNameForPreferredName:profileName];
+    if (taskProfileName.length > 0) taskItem.userInfo[@"profileName"] = taskProfileName;
+    taskItem.userInfo[@"destinationPath"] = destinationPath;
     // redesign-download-ui Phase 4：单文件下载接入统一进度页——
     // PLTaskStagesSingleFile 单阶段 + autoPresentDetail 自动弹出 PLTaskProgressViewController
     [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId stages:PLTaskStagesSingleFile()];
@@ -572,10 +553,11 @@
 
     // retryHandler：FCL 风格重新下载，复用同一 taskItem，重新发起 PLDownloadClient 请求
     __weak typeof(self) weakSelf = self;
+    __block PLDownloadRequest *retryRequest = nil;
     taskItem.retryHandler = ^id(DownloadTaskItem *taskItemRef) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) return nil;
-        return [strongSelf restartPLDownloadForTaskId:taskItemRef.taskId];
+        if (!strongSelf || !retryRequest) return nil;
+        return [strongSelf startPLDownloadWithRequest:retryRequest taskItem:taskItemRef progress:progress completion:completion];
     };
 
     PLDownloadRequest *request = [[PLDownloadRequest alloc] init];
@@ -593,6 +575,7 @@
     request.taskIdentifier = taskItem.taskId;
     // 无 SHA1 时对 .jar（zip 格式）做 EOCD 兜底完整性校验
     request.allowZipFallbackCheck = YES;
+    retryRequest = request;
 
     [self startPLDownloadWithRequest:request taskItem:taskItem progress:progress completion:completion];
 }
@@ -619,7 +602,6 @@
     self.downloadAccumulatedBytes[taskId] = @(0);
     self.downloadTotalBytes[taskId] = @(-1);
     self.downloadLastSpeeds[taskId] = @(0.0);
-    [self.downloadStateLock unlock];
 
     PLDownloadOperation *operation = [[PLDownloadClient sharedClient] startRequest:request
                                                                           progress:^(int64_t deltaBytes, int64_t totalExpectedBytes) {
@@ -639,12 +621,11 @@
     }];
     if (!operation) {
         // 参数错误：PLDownloadClient 会异步回调 completion（error），由统一失败路径收尾
+        [self.downloadStateLock unlock];
         return nil;
     }
 
-    [self.downloadStateLock lock];
     self.downloadOperations[taskId] = operation;
-    [self.downloadStateLock unlock];
 
     // rawTask 为 weak 引用：operation 由 PLDownloadClient 与本 Service 共同持有，
     // DownloadTaskManager 据此对 PLDownloadOperation 做 pause/resume/cancel
@@ -655,6 +636,8 @@
     [[DownloadTaskManager sharedManager] updateTaskWithId:taskId
                                               stageAtIndex:0
                                                   status:PLTaskStageStatusRunning];
+    // 与完成回调共用同一把锁，确保“注册为下载中”严格发生在任何终态之前。
+    [self.downloadStateLock unlock];
     return operation;
 }
 
@@ -746,20 +729,20 @@
     [self.downloadStateLock unlock];
 
     DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+    NSError *completionError = success ? nil : (error ?: [NSError errorWithDomain:@"ModServiceError" code:3 userInfo:@{NSLocalizedDescriptionKey: @"Mod download failed."}]);
     if (success) {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
-        [manager setTaskWithId:taskId state:DownloadTaskStateCompleted];
+        [manager setTaskWithId:taskId completedWithError:nil];
     } else if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
         // 用户取消（DownloadTaskManager 已置 Cancelled，这里幂等对齐）
         [manager setTaskWithId:taskId state:DownloadTaskStateCancelled];
     } else {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-        [manager updateTaskWithId:taskId error:error];
-        [manager setTaskWithId:taskId state:DownloadTaskStateFailed];
+        [manager setTaskWithId:taskId completedWithError:completionError];
     }
 
     if (completion) {
-        NSError *capturedError = success ? nil : error;
+        NSError *capturedError = completionError;
         dispatch_async(dispatch_get_main_queue(), ^{
             completion(capturedError);
         });

--- a/Natives/ModVersionViewController.h
+++ b/Natives/ModVersionViewController.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
 @property (nonatomic, strong) ModItem *modItem;
 @property (nonatomic, weak) id<ModVersionViewControllerDelegate> delegate;
+/// 初始 API 来源：1=Modrinth，2=CurseForge；默认 1。
+@property (nonatomic, assign) NSInteger initialSource;
 
 // FCL 风格：传入当前 profile 的偏好版本和加载器
 // ModVersionViewController 会优先选中匹配的 chip，并把匹配的版本置顶

--- a/Natives/ModVersionViewController.m
+++ b/Natives/ModVersionViewController.m
@@ -93,8 +93,8 @@ static NSArray<NSDictionary *> *SortOptionItems(void) {
     // 适配自定义启动器背景：透明化当前 VC，让全局背景图/毛玻璃透出
     [[BackgroundManager sharedManager] makeViewControllerTransparent:self];
 
-    // 初始化筛选状态（默认 Modrinth 源 + 相关性排序）
-    self.selectedSource = kSourceModrinth;
+    // 从搜索结果继承 API 来源，避免拿 CurseForge 数字 ID 请求 Modrinth。
+    self.selectedSource = self.initialSource == kSourceCurseForge ? kSourceCurseForge : kSourceModrinth;
     self.selectedSort = kSortRelevance;
 
     [self setupSideFilterPanel];

--- a/Natives/ModsManagerViewController.m
+++ b/Natives/ModsManagerViewController.m
@@ -18,6 +18,7 @@
 #import "PLProfiles.h"
 #import "LauncherPreferences.h"
 #import "DownloadViewController.h"
+#import "DownloadTaskManager.h"
 #import "utils.h"
 #import <CommonCrypto/CommonDigest.h>
 
@@ -146,6 +147,8 @@ static NSString *ModsManagerSHA1ForFile(NSString *path) {
 - (void)viewDidLoad {
     [super viewDidLoad]; // 基类构建背景/搜索栏/表格/空态/加载态/批量工具栏
 
+    self.profileName = [PLProfiles effectiveProfileNameForPreferredName:self.profileName];
+
     self.localMods = [NSMutableArray array];
     self.filteredLocalMods = [NSMutableArray array];
     self.modDates = [NSMutableDictionary dictionary];
@@ -158,7 +161,14 @@ static NSString *ModsManagerSHA1ForFile(NSString *path) {
     [self setupNavigationButtons];
     [self setupChipsRow];
     [self setupTableViewExtras];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDownloadTaskCompleted:)
+                                                 name:DownloadTaskManagerTaskCompletedNotification
+                                               object:nil];
+}
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [self loadMods];
 }
 
@@ -489,6 +499,8 @@ static NSString *ModsManagerSHA1ForFile(NSString *path) {
 /// 空状态"去下载"：跳转统一下载页（无参数化资源类型入口，进入默认页）
 - (void)openDownloadPage {
     DownloadViewController *vc = [[DownloadViewController alloc] init];
+    vc.initialTabIndex = 1;
+    vc.targetProfileName = self.profileName;
     if (self.navigationController) {
         [self.navigationController pushViewController:vc animated:YES];
     } else {
@@ -496,6 +508,14 @@ static NSString *ModsManagerSHA1ForFile(NSString *path) {
         nav.modalPresentationStyle = UIModalPresentationFullScreen;
         [self presentViewController:nav animated:YES completion:nil];
     }
+}
+
+- (void)handleDownloadTaskCompleted:(NSNotification *)notification {
+    DownloadTaskItem *task = notification.userInfo[DownloadTaskManagerTaskKey];
+    if (task.state != DownloadTaskStateCompleted ||
+        ![task.resourceType isEqualToString:DownloadTaskResourceTypeMod] ||
+        ![task.userInfo[@"profileName"] isEqualToString:self.profileName]) return;
+    [self loadMods];
 }
 
 #pragma mark - UISearchBarDelegate

--- a/Natives/PLProfiles.h
+++ b/Natives/PLProfiles.h
@@ -11,6 +11,12 @@
 + (id)profile:(NSMutableDictionary *)profile resolveKey:(id)key;
 + (NSString *)resolveKeyForCurrentProfile:(id)key;
 
+/// 优先使用 preferredName；无效时依次回退到当前选中档案和首个可用档案。
++ (NSString *)effectiveProfileNameForPreferredName:(NSString *)preferredName;
+
+/// 将档案 gameDir 统一解析为绝对路径（支持 "."、相对隔离目录和绝对目录）。
++ (NSString *)resolvedGameDirectoryForProfileName:(NSString *)profileName;
+
 - (id)initWithCurrentInstance;
 - (NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSString *> *> *)profiles;
 

--- a/Natives/PLProfiles.h
+++ b/Natives/PLProfiles.h
@@ -11,11 +11,13 @@
 + (id)profile:(NSMutableDictionary *)profile resolveKey:(id)key;
 + (NSString *)resolveKeyForCurrentProfile:(id)key;
 
-/// 优先使用 preferredName；无效时依次回退到当前选中档案和首个可用档案。
-+ (NSString *)effectiveProfileNameForPreferredName:(NSString *)preferredName;
+/// preferredName 非空时仅接受真实存在的档案，否则返回 nil；
+/// preferredName 为空时依次回退到当前选中档案和首个可用档案。
++ (nullable NSString *)effectiveProfileNameForPreferredName:(nullable NSString *)preferredName;
 
-/// 将档案 gameDir 统一解析为绝对路径（支持 "."、相对隔离目录和绝对目录）。
-+ (NSString *)resolvedGameDirectoryForProfileName:(NSString *)profileName;
+/// 将档案 gameDir 统一解析为绝对路径（支持 "."、相对隔离目录和绝对目录）；
+/// 显式指定不存在的档案时返回 nil。
++ (nullable NSString *)resolvedGameDirectoryForProfileName:(nullable NSString *)profileName;
 
 - (id)initWithCurrentInstance;
 - (NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSString *> *> *)profiles;

--- a/Natives/PLProfiles.m
+++ b/Natives/PLProfiles.m
@@ -41,6 +41,13 @@ static PLProfiles* current;
 
 + (id)profile:(NSMutableDictionary *)profile resolveKey:(id)key {
     id rawValue = profile[key];
+    // renderer 必须先做白名单规范化。显式 "auto" 是档案自己的选择，只有字段
+    // 缺失/空字符串时才允许继承全局默认，避免不同档案之间相互污染。
+    if ([key isEqual:@"renderer"] &&
+        [rawValue isKindOfClass:[NSString class]] &&
+        [(NSString *)rawValue length] > 0) {
+        return PLNormalizeRendererKey(rawValue);
+    }
     // 兼容 javaVersion 字段：Mojang 规范是 NSDictionary（{component, majorVersion}），
     // 但部分代码（如 ForgeDirectInstaller）也写入 NSDictionary。PLProfiles 期望返回 NSString。
     if ([rawValue isKindOfClass:[NSDictionary class]]) {
@@ -69,11 +76,49 @@ static PLProfiles* current;
         // 该字段仅在 MC 26.2+ 生效，旧版本会被 MC 忽略，无副作用。
         @"graphicsApi": @"video.graphics_api"
     };
-    return getPrefObject(prefDefaults[key]);
+    id prefValue = getPrefObject(prefDefaults[key]);
+    return [key isEqual:@"renderer"] ? PLNormalizeRendererKey(prefValue) : prefValue;
 }
 
 + (id)resolveKeyForCurrentProfile:(id)key {
     return [self profile:self.current.selectedProfile resolveKey:key];
+}
+
++ (NSString *)effectiveProfileNameForPreferredName:(NSString *)preferredName {
+    NSDictionary *profiles = self.current.profiles;
+    if (preferredName.length > 0 && [profiles[preferredName] isKindOfClass:[NSDictionary class]]) {
+        return preferredName;
+    }
+
+    NSString *selectedName = self.current.selectedProfileName;
+    if (selectedName.length > 0 && [profiles[selectedName] isKindOfClass:[NSDictionary class]]) {
+        return selectedName;
+    }
+
+    for (NSString *name in profiles) {
+        if ([name isKindOfClass:[NSString class]] && [profiles[name] isKindOfClass:[NSDictionary class]]) {
+            return name;
+        }
+    }
+    return nil;
+}
+
++ (NSString *)resolvedGameDirectoryForProfileName:(NSString *)profileName {
+    const char *gameDirC = getenv("POJAV_GAME_DIR");
+    NSString *baseDirectory = gameDirC ? [NSString stringWithUTF8String:gameDirC] : NSHomeDirectory();
+    NSString *effectiveName = [self effectiveProfileNameForPreferredName:profileName];
+    NSDictionary *profile = effectiveName.length > 0 ? self.current.profiles[effectiveName] : nil;
+    NSString *gameDir = [profile isKindOfClass:[NSDictionary class]] ? profile[@"gameDir"] : nil;
+
+    if (![gameDir isKindOfClass:[NSString class]] || gameDir.length == 0 || [gameDir isEqualToString:@"."]) {
+        return baseDirectory.stringByStandardizingPath;
+    }
+    if (gameDir.isAbsolutePath) {
+        return gameDir.stringByStandardizingPath;
+    }
+
+    NSString *relativePath = [gameDir hasPrefix:@"./"] ? [gameDir substringFromIndex:2] : gameDir;
+    return [[baseDirectory stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
 }
 
 - (id)initWithCurrentInstance {

--- a/Natives/PLProfiles.m
+++ b/Natives/PLProfiles.m
@@ -48,6 +48,13 @@ static PLProfiles* current;
         [(NSString *)rawValue length] > 0) {
         return PLNormalizeRendererKey(rawValue);
     }
+    // graphicsApi 与 renderer 使用相同的边界策略：档案显式值先做白名单
+    // 规范化；只有字段缺失/空字符串时才继承全局设置。
+    if ([key isEqual:@"graphicsApi"] &&
+        [rawValue isKindOfClass:[NSString class]] &&
+        [(NSString *)rawValue length] > 0) {
+        return PLNormalizeGraphicsApiKey(rawValue);
+    }
     // 兼容 javaVersion 字段：Mojang 规范是 NSDictionary（{component, majorVersion}），
     // 但部分代码（如 ForgeDirectInstaller）也写入 NSDictionary。PLProfiles 期望返回 NSString。
     if ([rawValue isKindOfClass:[NSDictionary class]]) {
@@ -77,17 +84,24 @@ static PLProfiles* current;
         @"graphicsApi": @"video.graphics_api"
     };
     id prefValue = getPrefObject(prefDefaults[key]);
-    return [key isEqual:@"renderer"] ? PLNormalizeRendererKey(prefValue) : prefValue;
+    if ([key isEqual:@"renderer"]) {
+        return PLNormalizeRendererKey(prefValue);
+    }
+    if ([key isEqual:@"graphicsApi"]) {
+        return PLNormalizeGraphicsApiKey(prefValue);
+    }
+    return prefValue;
 }
 
 + (id)resolveKeyForCurrentProfile:(id)key {
     return [self profile:self.current.selectedProfile resolveKey:key];
 }
 
-+ (NSString *)effectiveProfileNameForPreferredName:(NSString *)preferredName {
++ (nullable NSString *)effectiveProfileNameForPreferredName:(nullable NSString *)preferredName {
     NSDictionary *profiles = self.current.profiles;
-    if (preferredName.length > 0 && [profiles[preferredName] isKindOfClass:[NSDictionary class]]) {
-        return preferredName;
+    if (preferredName.length > 0) {
+        // 显式指定的目标不能静默落到当前或任意首个档案，否则下载可能写错实例。
+        return [profiles[preferredName] isKindOfClass:[NSDictionary class]] ? preferredName : nil;
     }
 
     NSString *selectedName = self.current.selectedProfileName;
@@ -103,22 +117,29 @@ static PLProfiles* current;
     return nil;
 }
 
-+ (NSString *)resolvedGameDirectoryForProfileName:(NSString *)profileName {
++ (nullable NSString *)resolvedGameDirectoryForProfileName:(nullable NSString *)profileName {
     const char *gameDirC = getenv("POJAV_GAME_DIR");
-    NSString *baseDirectory = gameDirC ? [NSString stringWithUTF8String:gameDirC] : NSHomeDirectory();
+    NSString *baseDirectory = (gameDirC ? [NSString stringWithUTF8String:gameDirC] : NSHomeDirectory()).stringByStandardizingPath;
+    if (!baseDirectory.isAbsolutePath) return nil;
     NSString *effectiveName = [self effectiveProfileNameForPreferredName:profileName];
-    NSDictionary *profile = effectiveName.length > 0 ? self.current.profiles[effectiveName] : nil;
-    NSString *gameDir = [profile isKindOfClass:[NSDictionary class]] ? profile[@"gameDir"] : nil;
+    if (effectiveName.length == 0) return nil;
+    NSDictionary *profile = self.current.profiles[effectiveName];
+    NSString *gameDir = profile[@"gameDir"];
 
     if (![gameDir isKindOfClass:[NSString class]] || gameDir.length == 0 || [gameDir isEqualToString:@"."]) {
-        return baseDirectory.stringByStandardizingPath;
+        return baseDirectory;
     }
     if (gameDir.isAbsolutePath) {
         return gameDir.stringByStandardizingPath;
     }
 
     NSString *relativePath = [gameDir hasPrefix:@"./"] ? [gameDir substringFromIndex:2] : gameDir;
-    return [[baseDirectory stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
+    NSString *resolvedPath = [[baseDirectory stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
+    NSString *basePrefix = [baseDirectory stringByAppendingString:@"/"];
+    if (![resolvedPath isEqualToString:baseDirectory] && ![resolvedPath hasPrefix:basePrefix]) {
+        return nil;
+    }
+    return resolvedPath;
 }
 
 - (id)initWithCurrentInstance {

--- a/Natives/PLTaskProgressViewController.m
+++ b/Natives/PLTaskProgressViewController.m
@@ -7,6 +7,7 @@
 #import "BackgroundManager.h"
 #import "ModLoaderIconHelper.h"
 #import "IconLoader.h"
+#include <math.h>
 
 #pragma mark - 常量与辅助
 
@@ -350,7 +351,10 @@ static NSString *PLFormatDuration(NSTimeInterval seconds) {
         self.flowView.hidden = YES;
         [self.flowView stopFlowing];
         [self.progressView setProgress:(float)clamped animated:NO];
-        NSString *percent = [NSString stringWithFormat:@"%.0f%%", clamped * 100.0];
+        NSInteger displayPercent = (stage.status == PLTaskStageStatusCompleted)
+            ? 100
+            : MIN(99, (NSInteger)floor(clamped * 100.0));
+        NSString *percent = [NSString stringWithFormat:@"%ld%%", (long)displayPercent];
         self.percentRateLabel.text = rateText ? [NSString stringWithFormat:@"%@ · %@", percent, rateText] : percent;
     } else {
         self.progressView.hidden = YES;
@@ -969,7 +973,9 @@ static __weak PLTaskProgressViewController *PLTaskProgressActiveInstance = nil;
         case DownloadTaskStatePending:
             return PLTaskProgressText(@"taskProgress.state.pending", localize(@"i18n_str_124", nil));
         case DownloadTaskStateDownloading:
-            return PLTaskProgressText(@"taskProgress.state.downloading", localize(@"i18n_str_138", nil));
+            return [task.userInfo[DownloadTaskUserInfoTransferCompleteKey] boolValue]
+                ? localize(@"i18n_str_78", nil)
+                : PLTaskProgressText(@"taskProgress.state.downloading", localize(@"i18n_str_138", nil));
         case DownloadTaskStatePaused:
             return PLTaskProgressText(@"taskProgress.state.paused", localize(@"i18n_str_125", nil));
         case DownloadTaskStateCompleted:
@@ -1123,7 +1129,11 @@ static __weak PLTaskProgressViewController *PLTaskProgressActiveInstance = nil;
         self.totalFlowView.hidden = YES;
         [self.totalFlowView stopFlowing];
         [self.totalProgressView setProgress:(float)MIN(1.0, MAX(0.0, overall)) animated:NO];
-        NSString *percent = [NSString stringWithFormat:@"%.0f%%", overall * 100.0];
+        double clampedOverall = MIN(1.0, MAX(0.0, overall));
+        NSInteger displayPercent = (task.state == DownloadTaskStateCompleted)
+            ? 100
+            : MIN(99, (NSInteger)floor(clampedOverall * 100.0));
+        NSString *percent = [NSString stringWithFormat:@"%ld%%", (long)displayPercent];
         self.totalValueLabel.text = rateText ? [NSString stringWithFormat:@"%@ · %@", percent, rateText] : percent;
     } else {
         // 不确定进度：流动动画，不显示百分比

--- a/Natives/PLTaskStages.h
+++ b/Natives/PLTaskStages.h
@@ -137,6 +137,14 @@ NS_INLINE NSArray<PLTaskStage *> *PLTaskStagesSingleFile(void) {
     ];
 }
 
+/// 世界下载 2 步：下载压缩包→解压并验证 level.dat
+NS_INLINE NSArray<PLTaskStage *> *PLTaskStagesWorld(void) {
+    return @[
+        [PLTaskStage stageWithTitle:PLTaskStageTitleDownloadFile iconName:@"arrow.down.circle"],
+        [PLTaskStage stageWithTitle:PLTaskStageTitleExtractFiles iconName:@"archivebox"],
+    ];
+}
+
 #pragma mark - 阶段标题渲染（UI 层共用，redesign-download-ui Phase 2）
 
 /// 渲染阶段标题为用户可见文案：PLTaskStage.title 存储本地化 key，

--- a/Natives/ProfileSettingsViewController.m
+++ b/Natives/ProfileSettingsViewController.m
@@ -474,14 +474,14 @@ static NSString * localizeProfileTitle(NSString *title) {
     self.selectedRenderer = ([profileRenderer isKindOfClass:[NSString class]] &&
                              [(NSString *)profileRenderer length] > 0)
         ? PLNormalizeRendererKey(profileRenderer)
-        : @"(default)";
+        : PLProfileInheritedValue;
 
     // 图形 API（MC 26.2+ 游戏内 OpenGL/Vulkan 切换）
     id profileGraphicsApi = self.profile[@"graphicsApi"];
     self.selectedGraphicsApi = ([profileGraphicsApi isKindOfClass:[NSString class]] &&
                                 [(NSString *)profileGraphicsApi length] > 0)
-        ? profileGraphicsApi
-        : @"(default)";
+        ? PLNormalizeGraphicsApiKey(profileGraphicsApi)
+        : PLProfileInheritedValue;
 
     // Java版本（兼容旧版直装器写入的 NSDictionary 格式）
     id javaVerRaw = self.profile[@"javaVersion"];
@@ -624,15 +624,15 @@ static NSString * localizeProfileTitle(NSString *title) {
     if (!existing) {
         existing = [NSMutableDictionary dictionary];
     }
-    if ([self.selectedRenderer isEqualToString:@"(default)"]) {
+    if ([self.selectedRenderer isEqualToString:PLProfileInheritedValue]) {
         [existing removeObjectForKey:@"renderer"];
     } else {
         existing[@"renderer"] = PLNormalizeRendererKey(self.selectedRenderer);
     }
-    if ([self.selectedGraphicsApi isEqualToString:@"(default)"]) {
+    if ([self.selectedGraphicsApi isEqualToString:PLProfileInheritedValue]) {
         [existing removeObjectForKey:@"graphicsApi"];
     } else {
-        existing[@"graphicsApi"] = self.selectedGraphicsApi;
+        existing[@"graphicsApi"] = PLNormalizeGraphicsApiKey(self.selectedGraphicsApi);
     }
     existing[@"javaVersion"] = self.selectedJavaVersion;
     existing[@"allocatedMemory"] = @(self.allocatedMemory);
@@ -2055,9 +2055,12 @@ static NSString * localizeProfileTitle(NSString *title) {
 
 /// 图形 API 显示名
 - (NSString *)graphicsApiDisplayName:(NSString *)api {
-    if ([api isEqualToString:@"(default)"]) return @"(default)";
-    if ([api isEqualToString:@"prefer_vulkan"]) return localize(@"i18n_str_941", nil);
-    if ([api isEqualToString:@"prefer_opengl"]) return localize(@"i18n_str_942", nil);
+    NSArray *keys = getGraphicsApiKeys(YES);
+    NSArray *names = getGraphicsApiNames(YES);
+    NSUInteger idx = [keys indexOfObject:api];
+    if (idx != NSNotFound && idx < names.count) {
+        return names[idx];
+    }
     return localize(@"i18n_str_943", nil);
 }
 
@@ -2067,8 +2070,8 @@ static NSString * localizeProfileTitle(NSString *title) {
                                                                    message:localize(@"i18n_str_945", nil)
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
 
-    NSArray *keys = @[@"(default)", @"default", @"prefer_vulkan", @"prefer_opengl"];
-    NSArray *names = @[@"(default)", localize(@"i18n_str_943", nil), localize(@"i18n_str_941", nil), localize(@"i18n_str_942", nil)];
+    NSArray *keys = getGraphicsApiKeys(YES);
+    NSArray *names = getGraphicsApiNames(YES);
 
     for (NSInteger i = 0; i < keys.count; i++) {
         NSString *key = keys[i];

--- a/Natives/ProfileSettingsViewController.m
+++ b/Natives/ProfileSettingsViewController.m
@@ -470,10 +470,18 @@ static NSString * localizeProfileTitle(NSString *title) {
 
 - (void)loadSettings {
     // 渲染器
-    self.selectedRenderer = self.profile[@"renderer"] ?: @"auto";
+    id profileRenderer = self.profile[@"renderer"];
+    self.selectedRenderer = ([profileRenderer isKindOfClass:[NSString class]] &&
+                             [(NSString *)profileRenderer length] > 0)
+        ? PLNormalizeRendererKey(profileRenderer)
+        : @"(default)";
 
     // 图形 API（MC 26.2+ 游戏内 OpenGL/Vulkan 切换）
-    self.selectedGraphicsApi = self.profile[@"graphicsApi"] ?: @"default";
+    id profileGraphicsApi = self.profile[@"graphicsApi"];
+    self.selectedGraphicsApi = ([profileGraphicsApi isKindOfClass:[NSString class]] &&
+                                [(NSString *)profileGraphicsApi length] > 0)
+        ? profileGraphicsApi
+        : @"(default)";
 
     // Java版本（兼容旧版直装器写入的 NSDictionary 格式）
     id javaVerRaw = self.profile[@"javaVersion"];
@@ -616,8 +624,16 @@ static NSString * localizeProfileTitle(NSString *title) {
     if (!existing) {
         existing = [NSMutableDictionary dictionary];
     }
-    existing[@"renderer"] = self.selectedRenderer;
-    existing[@"graphicsApi"] = self.selectedGraphicsApi;
+    if ([self.selectedRenderer isEqualToString:@"(default)"]) {
+        [existing removeObjectForKey:@"renderer"];
+    } else {
+        existing[@"renderer"] = PLNormalizeRendererKey(self.selectedRenderer);
+    }
+    if ([self.selectedGraphicsApi isEqualToString:@"(default)"]) {
+        [existing removeObjectForKey:@"graphicsApi"];
+    } else {
+        existing[@"graphicsApi"] = self.selectedGraphicsApi;
+    }
     existing[@"javaVersion"] = self.selectedJavaVersion;
     existing[@"allocatedMemory"] = @(self.allocatedMemory);
     existing[@"serverIp"] = self.serverIp ?: @"";
@@ -1096,8 +1112,8 @@ static NSString * localizeProfileTitle(NSString *title) {
 #pragma mark - Helpers
 
 - (NSString *)rendererDisplayName:(NSString *)renderer {
-    NSArray *keys = getRendererKeys(NO);
-    NSArray *names = getRendererNames(NO);
+    NSArray *keys = getRendererKeys(YES);
+    NSArray *names = getRendererNames(YES);
     NSUInteger idx = [keys indexOfObject:renderer];
     if (idx != NSNotFound && idx < names.count) {
         return names[idx];
@@ -1988,8 +2004,8 @@ static NSString * localizeProfileTitle(NSString *title) {
                                                                    message:nil
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
 
-    NSArray *renderers = getRendererKeys(NO);
-    NSArray *displayNames = getRendererNames(NO);
+    NSArray *renderers = getRendererKeys(YES);
+    NSArray *displayNames = getRendererNames(YES);
 
     for (NSInteger i = 0; i < renderers.count; i++) {
         NSString *renderer = renderers[i];
@@ -2039,6 +2055,7 @@ static NSString * localizeProfileTitle(NSString *title) {
 
 /// 图形 API 显示名
 - (NSString *)graphicsApiDisplayName:(NSString *)api {
+    if ([api isEqualToString:@"(default)"]) return @"(default)";
     if ([api isEqualToString:@"prefer_vulkan"]) return localize(@"i18n_str_941", nil);
     if ([api isEqualToString:@"prefer_opengl"]) return localize(@"i18n_str_942", nil);
     return localize(@"i18n_str_943", nil);
@@ -2050,8 +2067,8 @@ static NSString * localizeProfileTitle(NSString *title) {
                                                                    message:localize(@"i18n_str_945", nil)
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
 
-    NSArray *keys = @[@"default", @"prefer_vulkan", @"prefer_opengl"];
-    NSArray *names = @[localize(@"i18n_str_943", nil), localize(@"i18n_str_941", nil), localize(@"i18n_str_942", nil)];
+    NSArray *keys = @[@"(default)", @"default", @"prefer_vulkan", @"prefer_opengl"];
+    NSArray *names = @[@"(default)", localize(@"i18n_str_943", nil), localize(@"i18n_str_941", nil), localize(@"i18n_str_942", nil)];
 
     for (NSInteger i = 0; i < keys.count; i++) {
         NSString *key = keys[i];

--- a/Natives/ResourcePackItem.h
+++ b/Natives/ResourcePackItem.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // --- 在线资源包属性 ---
 @property (nonatomic, copy, nullable) NSString *onlineID;
+/// 在线 API 来源：1=Modrinth，2=CurseForge。
+@property (nonatomic, assign) NSInteger apiSource;
 @property (nonatomic, copy, nullable) NSString *author;
 @property (nonatomic, strong, nullable) NSNumber *downloads;
 @property (nonatomic, strong, nullable) NSNumber *likes;

--- a/Natives/ResourcePackItem.m
+++ b/Natives/ResourcePackItem.m
@@ -31,6 +31,7 @@
     if (self = [super init]) {
         // 来自 Modrinth 搜索结果
         _onlineID = data[@"id"] ? [data[@"id"] description] : nil;
+        _apiSource = [data[@"apiSource"] integerValue] == 2 ? 2 : 1;
         _displayName = data[@"title"] ?: @"";
         _resourcePackDescription = data[@"description"] ?: @"";
         _iconURL = data[@"imageUrl"] ?: @"";

--- a/Natives/ResourcePackService.h
+++ b/Natives/ResourcePackService.h
@@ -30,7 +30,7 @@ typedef void(^ResourcePackDownloadProgressHandler)(NSProgress * _Nullable downlo
 
 // --- 本地资源包管理 ---
 // 扫描指定 profile 的 resourcepacks 目录，返回 .zip 和 .zip.disabled 文件列表
-- (void)scanResourcePacksForProfile:(NSString *)profileName completion:(ResourcePackListHandler)completion;
+- (void)scanResourcePacksForProfile:(NSString * _Nullable)profileName completion:(ResourcePackListHandler)completion;
 // 获取资源包元数据（解析 zip 内的 pack.mcmeta，获取 pack_format 和 description）
 - (void)fetchMetadataForResourcePack:(ResourcePackItem *)item completion:(ResourcePackMetadataHandler)completion;
 // 启用/禁用资源包（加/去 .disabled 后缀）
@@ -41,7 +41,7 @@ typedef void(^ResourcePackDownloadProgressHandler)(NSProgress * _Nullable downlo
 // --- 在线资源包下载 ---
 // 下载资源包到指定 profile 的 resourcepacks 目录，支持实时进度回调
 - (void)downloadResourcePack:(ResourcePackItem *)item
-                   toProfile:(NSString *)profileName
+                   toProfile:(NSString * _Nullable)profileName
                     progress:(ResourcePackDownloadProgressHandler _Nullable)progress
                   completion:(ResourcePackDownloadCompletionHandler _Nullable)completion;
 
@@ -50,7 +50,7 @@ typedef void(^ResourcePackDownloadProgressHandler)(NSProgress * _Nullable downlo
 /// CurseForge hashes algo=1），传入即启用校验，校验失败由统一下载器按镜像/退避节奏重试；
 /// 为 nil 时不做 SHA1 校验，靠 zip EOCD 兜底校验保证完整性。
 - (void)downloadResourcePack:(ResourcePackItem *)item
-                   toProfile:(NSString *)profileName
+                   toProfile:(NSString * _Nullable)profileName
                 expectedSHA1:(nullable NSString *)expectedSHA1
                     progress:(ResourcePackDownloadProgressHandler _Nullable)progress
                   completion:(ResourcePackDownloadCompletionHandler _Nullable)completion;
@@ -59,7 +59,7 @@ typedef void(^ResourcePackDownloadProgressHandler)(NSProgress * _Nullable downlo
 - (NSString *)iconCachePathForURL:(NSString *)urlString;
 
 /// 获取当前 profile 的 resourcepacks 目录，不存在时自动创建
-- (nullable NSString *)ensureResourcePacksFolderForProfile:(NSString *)profileName error:(NSError **)error;
+- (nullable NSString *)ensureResourcePacksFolderForProfile:(NSString * _Nullable)profileName error:(NSError **)error;
 
 @end
 

--- a/Natives/ResourcePackService.m
+++ b/Natives/ResourcePackService.m
@@ -134,6 +134,7 @@
 - (nullable NSString *)existingResourcePacksFolderForProfile:(NSString *)profileName {
     NSFileManager *fm = [NSFileManager defaultManager];
     NSString *gameDir = [PLProfiles resolvedGameDirectoryForProfileName:profileName];
+    if (gameDir.length == 0) return nil;
     NSString *resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
     BOOL isDir = NO;
     if ([fm fileExistsAtPath:resourcePacksPath isDirectory:&isDir] && isDir) return resourcePacksPath;
@@ -278,54 +279,16 @@
                     progress:(ResourcePackDownloadProgressHandler _Nullable)progress
                   completion:(ResourcePackDownloadCompletionHandler _Nullable)completion {
     // 确保 resourcepacks 目录存在
-    NSString *resourcePacksFolder = [self existingResourcePacksFolderForProfile:profileName];
-    NSFileManager *fm = [NSFileManager defaultManager];
-
+    NSError *folderError = nil;
+    NSString *resourcePacksFolder = [self ensureResourcePacksFolderForProfile:profileName error:&folderError];
     if (!resourcePacksFolder) {
-        // 目录不存在时尝试创建
-        NSString *profile = profileName.length ? profileName : @"default";
-        NSString *gameDir = nil;
-
-        @try {
-            NSDictionary *profiles = PLProfiles.current.profiles;
-            NSDictionary *prof = profiles[profile];
-            if ([prof isKindOfClass:[NSDictionary class]]) {
-                gameDir = prof[@"gameDir"];
-            }
-        } @catch (NSException *ex) { }
-
-        if (!gameDir) {
-            const char *gameDirC = getenv("POJAV_GAME_DIR");
-            if (gameDirC) {
-                gameDir = [NSString stringWithUTF8String:gameDirC];
-            }
+        if (completion) {
+            NSError *error = folderError ?: [NSError errorWithDomain:@"ResourcePackServiceError"
+                                                              code:1
+                                                          userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_106", nil)}];
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(NO, error); });
         }
-
-        if (gameDir) {
-            resourcePacksFolder = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
-            NSError *dirError = nil;
-            BOOL created = [fm createDirectoryAtPath:resourcePacksFolder
-                         withIntermediateDirectories:YES
-                                          attributes:nil
-                                               error:&dirError];
-            if (!created || dirError) {
-                if (completion) {
-                    NSError *error = [NSError errorWithDomain:@"ResourcePackServiceError"
-                                                         code:1
-                                                     userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_951", nil)}];
-                    dispatch_async(dispatch_get_main_queue(), ^{ completion(NO, error); });
-                }
-                return;
-            }
-        } else {
-            if (completion) {
-                NSError *error = [NSError errorWithDomain:@"ResourcePackServiceError"
-                                                     code:1
-                                                 userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_106", nil)}];
-                dispatch_async(dispatch_get_main_queue(), ^{ completion(NO, error); });
-            }
-            return;
-        }
+        return;
     }
 
     // 校验下载链接

--- a/Natives/ResourcePackService.m
+++ b/Natives/ResourcePackService.m
@@ -132,61 +132,19 @@
 
 // 查找指定 profile 的 resourcepacks 目录（已存在时返回路径，否则返回 nil）
 - (nullable NSString *)existingResourcePacksFolderForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                NSString *resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
-                BOOL isDir = NO;
-                if ([fm fileExistsAtPath:resourcePacksPath isDirectory:&isDir] && isDir) {
-                    return resourcePacksPath;
-                }
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    // 回退：读取 POJAV_GAME_DIR 环境变量
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-        NSString *resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:resourcePacksPath isDirectory:&isDir] && isDir) {
-            return resourcePacksPath;
-        }
-    }
+    NSString *gameDir = [PLProfiles resolvedGameDirectoryForProfileName:profileName];
+    NSString *resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
+    BOOL isDir = NO;
+    if ([fm fileExistsAtPath:resourcePacksPath isDirectory:&isDir] && isDir) return resourcePacksPath;
     return nil;
 }
 
 /// 获取当前 profile 的 resourcepacks 目录，不存在时自动创建
 - (nullable NSString *)ensureResourcePacksFolderForProfile:(NSString *)profileName error:(NSError **)error {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *resourcePacksPath = nil;
-
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    if (!resourcePacksPath) {
-        const char *gameDirC = getenv("POJAV_GAME_DIR");
-        if (gameDirC) {
-            NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-            resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
-        }
-    }
+    NSString *gameDir = [PLProfiles resolvedGameDirectoryForProfileName:profileName];
+    NSString *resourcePacksPath = [gameDir stringByAppendingPathComponent:@"resourcepacks"];
 
     if (!resourcePacksPath) {
         if (error) {
@@ -409,6 +367,9 @@
                       supportsResume:YES
                              iconURL:item.iconURL];
     taskItem.downloadURL = item.selectedVersionDownloadURL;
+    NSString *taskProfileName = [PLProfiles effectiveProfileNameForPreferredName:profileName];
+    if (taskProfileName.length > 0) taskItem.userInfo[@"profileName"] = taskProfileName;
+    taskItem.userInfo[@"destinationPath"] = destinationPath;
     // redesign-download-ui Phase 3：单文件下载接入统一进度页——
     // PLTaskStagesSingleFile 单阶段 + autoPresentDetail 自动弹出 PLTaskProgressViewController
     [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId stages:PLTaskStagesSingleFile()];
@@ -416,10 +377,11 @@
 
     // retryHandler：FCL 风格重新下载，复用同一 taskItem，重新发起 PLDownloadClient 请求
     __weak typeof(self) weakSelf = self;
+    __block PLDownloadRequest *retryRequest = nil;
     taskItem.retryHandler = ^id(DownloadTaskItem *taskItemRef) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) return nil;
-        return [strongSelf restartPLDownloadForTaskId:taskItemRef.taskId];
+        if (!strongSelf || !retryRequest) return nil;
+        return [strongSelf startPLDownloadWithRequest:retryRequest taskItem:taskItemRef progress:progress completion:completion];
     };
 
     PLDownloadRequest *request = [[PLDownloadRequest alloc] init];
@@ -437,6 +399,7 @@
     request.taskIdentifier = taskItem.taskId;
     // 无 SHA1 时对 .zip 做 EOCD 兜底完整性校验
     request.allowZipFallbackCheck = YES;
+    retryRequest = request;
 
     [self startPLDownloadWithRequest:request taskItem:taskItem progress:progress completion:completion];
 
@@ -465,7 +428,6 @@
     self.downloadAccumulatedBytes[taskId] = @(0);
     self.downloadTotalBytes[taskId] = @(-1);
     self.downloadLastSpeeds[taskId] = @(0.0);
-    [self.downloadStateLock unlock];
 
     PLDownloadOperation *operation = [[PLDownloadClient sharedClient] startRequest:request
                                                                           progress:^(int64_t deltaBytes, int64_t totalExpectedBytes) {
@@ -485,12 +447,11 @@
     }];
     if (!operation) {
         // 参数错误：PLDownloadClient 会异步回调 completion（error），由统一失败路径收尾
+        [self.downloadStateLock unlock];
         return nil;
     }
 
-    [self.downloadStateLock lock];
     self.downloadOperations[taskId] = operation;
-    [self.downloadStateLock unlock];
 
     // rawTask 为 weak 引用：operation 由 PLDownloadClient 与本 Service 共同持有，
     // DownloadTaskManager 据此对 PLDownloadOperation 做 pause/resume/cancel
@@ -501,6 +462,7 @@
     [[DownloadTaskManager sharedManager] updateTaskWithId:taskId
                                               stageAtIndex:0
                                                   status:PLTaskStageStatusRunning];
+    [self.downloadStateLock unlock];
     return operation;
 }
 
@@ -593,21 +555,21 @@
     [self.downloadStateLock unlock];
 
     DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+    NSError *completionError = success ? nil : (error ?: [NSError errorWithDomain:@"ResourcePackServiceError" code:3 userInfo:@{NSLocalizedDescriptionKey: @"Resource pack download failed."}]);
     if (success) {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
-        [manager setTaskWithId:taskId state:DownloadTaskStateCompleted];
+        [manager setTaskWithId:taskId completedWithError:nil];
     } else if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
         // 用户取消（DownloadTaskManager 已置 Cancelled，这里幂等对齐）
         [manager setTaskWithId:taskId state:DownloadTaskStateCancelled];
     } else {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-        [manager updateTaskWithId:taskId error:error];
-        [manager setTaskWithId:taskId state:DownloadTaskStateFailed];
+        [manager setTaskWithId:taskId completedWithError:completionError];
     }
 
     if (completion) {
         BOOL successFlag = success ? YES : NO;
-        NSError *capturedError = success ? nil : error;
+        NSError *capturedError = completionError;
         dispatch_async(dispatch_get_main_queue(), ^{
             completion(successFlag, capturedError);
         });

--- a/Natives/ResourcePacksManagerViewController.m
+++ b/Natives/ResourcePacksManagerViewController.m
@@ -12,6 +12,8 @@
 #import "ResourcePackItem.h"
 #import "ResourceCardTableViewCell.h"
 #import "DownloadViewController.h"
+#import "DownloadTaskManager.h"
+#import "PLProfiles.h"
 #import "utils.h"
 
 #pragma mark - 资源包卡片 Cell（继承 Air-Design 卡片基类，本文件内轻量子类）
@@ -86,6 +88,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.profileName = [PLProfiles effectiveProfileNameForPreferredName:self.profileName];
     // 在线下载入口已移至下载界面：固定本地模式（currentMode 等属性保留仅为兼容 .h 既有声明）
     self.currentMode = ResourcePacksManagerModeLocal;
     self.localItems = [NSMutableArray array];
@@ -115,6 +118,14 @@
     self.navigationItem.leftBarButtonItem = closeButton;
     self.navigationItem.rightBarButtonItems = @[self.importButton, self.refreshButton];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDownloadTaskCompleted:)
+                                                 name:DownloadTaskManagerTaskCompletedNotification
+                                               object:nil];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [self refreshLocalList];
 }
 
@@ -279,6 +290,8 @@
 - (void)openDownloadPage {
     // 在线下载入口已收敛到统一下载界面（未区分资源类型 Tab，进入默认页）
     DownloadViewController *downloadVC = [[DownloadViewController alloc] init];
+    downloadVC.initialTabIndex = 3;
+    downloadVC.targetProfileName = self.profileName;
     if (self.navigationController) {
         [self.navigationController pushViewController:downloadVC animated:YES];
     } else {
@@ -287,6 +300,14 @@
         nav.modalPresentationStyle = UIModalPresentationFullScreen;
         [self presentViewController:nav animated:YES completion:nil];
     }
+}
+
+- (void)handleDownloadTaskCompleted:(NSNotification *)notification {
+    DownloadTaskItem *task = notification.userInfo[DownloadTaskManagerTaskKey];
+    if (task.state != DownloadTaskStateCompleted ||
+        ![task.resourceType isEqualToString:DownloadTaskResourceTypeResourcePack] ||
+        ![task.userInfo[@"profileName"] isEqualToString:self.profileName]) return;
+    [self refreshLocalList];
 }
 
 #pragma mark - UITableView DataSource & Delegate

--- a/Natives/ShaderItem.h
+++ b/Natives/ShaderItem.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // --- Properties for Online Shaders ---
 @property (nonatomic, copy, nullable) NSString *onlineID;
+/// 在线 API 来源：1=Modrinth，2=CurseForge。
+@property (nonatomic, assign) NSInteger apiSource;
 @property (nonatomic, copy, nullable) NSString *author;
 @property (nonatomic, strong, nullable) NSNumber *downloads;
 @property (nonatomic, strong, nullable) NSNumber *likes;

--- a/Natives/ShaderItem.m
+++ b/Natives/ShaderItem.m
@@ -31,6 +31,7 @@
     if (self = [super init]) {
         // Data from Modrinth search results
         _onlineID = data[@"id"] ? [data[@"id"] description] : nil;
+        _apiSource = [data[@"apiSource"] integerValue] == 2 ? 2 : 1;
         _displayName = data[@"title"] ?: @"";
         _shaderDescription = data[@"description"] ?: @"";
         _iconURL = data[@"imageUrl"] ?: @"";

--- a/Natives/ShaderService.h
+++ b/Natives/ShaderService.h
@@ -21,17 +21,17 @@ typedef void(^ShaderDownloadHandler)(NSError * _Nullable error);
 + (instancetype)sharedService;
 
 // --- Local Shader Management ---
-- (void)scanShadersForProfile:(NSString *)profileName completion:(ShaderListHandler)completion;
+- (void)scanShadersForProfile:(NSString * _Nullable)profileName completion:(ShaderListHandler)completion;
 - (void)fetchMetadataForShader:(ShaderItem *)shader completion:(ShaderMetadataHandler)completion;
 - (BOOL)toggleEnableForShader:(ShaderItem *)shader error:(NSError **)error;
 - (BOOL)deleteShader:(ShaderItem *)shader error:(NSError **)error;
 
 // --- Online Shader Downloading ---
-- (void)downloadShader:(ShaderItem *)shader toProfile:(NSString *)profileName completion:(ShaderDownloadHandler)completion;
+- (void)downloadShader:(ShaderItem *)shader toProfile:(NSString * _Nullable)profileName completion:(ShaderDownloadHandler)completion;
 
 /// 下载光影包并上报进度
 - (void)downloadShader:(ShaderItem *)shader
-             toProfile:(NSString *)profileName
+             toProfile:(NSString * _Nullable)profileName
               progress:(void (^)(NSProgress *downloadProgress))progress
             completion:(ShaderDownloadHandler)completion;
 
@@ -40,7 +40,7 @@ typedef void(^ShaderDownloadHandler)(NSError * _Nullable error);
 /// 传入即启用校验，校验失败由统一下载器按镜像/退避节奏重试；
 /// 为 nil 时不做 SHA1 校验，靠 zip EOCD 兜底校验保证完整性。
 - (void)downloadShader:(ShaderItem *)shader
-             toProfile:(NSString *)profileName
+             toProfile:(NSString * _Nullable)profileName
           expectedSHA1:(nullable NSString *)expectedSHA1
               progress:(nullable void (^)(NSProgress *downloadProgress))progress
             completion:(ShaderDownloadHandler)completion;
@@ -49,7 +49,7 @@ typedef void(^ShaderDownloadHandler)(NSError * _Nullable error);
 - (NSString *)iconCachePathForURL:(NSString *)urlString;
 
 /// 获取当前 profile 的 shaderpacks 目录，不存在时自动创建
-- (nullable NSString *)ensureShadersFolderForProfile:(NSString *)profileName error:(NSError **)error;
+- (nullable NSString *)ensureShadersFolderForProfile:(NSString * _Nullable)profileName error:(NSError **)error;
 
 @end
 

--- a/Natives/ShaderService.m
+++ b/Natives/ShaderService.m
@@ -110,27 +110,7 @@
 /// 用户点击下载光影按钮后没反应（实际是 ensureShadersFolderForProfile 创建目录到错误位置，
 /// 下载完成后 moveItem 失败但 handler 已切主线程报错，用户感知"无反应"）。
 - (nullable NSString *)resolveAbsoluteGameDirForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if (![prof isKindOfClass:[NSDictionary class]]) return nil;
-        NSString *gameDir = prof[@"gameDir"];
-        if (![gameDir isKindOfClass:[NSString class]] || gameDir.length == 0) return nil;
-        if ([gameDir isEqualToString:@"."]) {
-            const char *env = getenv("POJAV_GAME_DIR");
-            return env ? [NSString stringWithUTF8String:env] : NSHomeDirectory();
-        }
-        if ([gameDir isAbsolutePath]) {
-            return gameDir;
-        }
-        const char *env = getenv("POJAV_GAME_DIR");
-        NSString *baseDir = env ? [NSString stringWithUTF8String:env] : NSHomeDirectory();
-        NSString *cleanGameDir = [gameDir hasPrefix:@"./"] ? [gameDir substringFromIndex:2] : gameDir;
-        return [baseDir stringByAppendingPathComponent:cleanGameDir];
-    } @catch (NSException *ex) {
-        return nil;
-    }
+    return [PLProfiles resolvedGameDirectoryForProfileName:profileName];
 }
 
 - (nullable NSString *)existingShadersFolderForProfile:(NSString *)profileName {
@@ -370,6 +350,9 @@
                       supportsResume:YES
                              iconURL:shader.iconURL];
     taskItem.downloadURL = shader.selectedVersionDownloadURL;
+    NSString *taskProfileName = [PLProfiles effectiveProfileNameForPreferredName:profileName];
+    if (taskProfileName.length > 0) taskItem.userInfo[@"profileName"] = taskProfileName;
+    taskItem.userInfo[@"destinationPath"] = destinationPath;
     // redesign-download-ui Phase 4：单文件下载接入统一进度页——
     // PLTaskStagesSingleFile 单阶段 + autoPresentDetail 自动弹出 PLTaskProgressViewController
     [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId stages:PLTaskStagesSingleFile()];
@@ -377,10 +360,11 @@
 
     // retryHandler：FCL 风格重新下载，复用同一 taskItem，重新发起 PLDownloadClient 请求
     __weak typeof(self) weakSelf = self;
+    __block PLDownloadRequest *retryRequest = nil;
     taskItem.retryHandler = ^id(DownloadTaskItem *taskItemRef) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) return nil;
-        return [strongSelf restartPLDownloadForTaskId:taskItemRef.taskId];
+        if (!strongSelf || !retryRequest) return nil;
+        return [strongSelf startPLDownloadWithRequest:retryRequest taskItem:taskItemRef progress:progress completion:completion];
     };
 
     PLDownloadRequest *request = [[PLDownloadRequest alloc] init];
@@ -397,6 +381,7 @@
     request.taskIdentifier = taskItem.taskId;
     // 无 SHA1 时对 .zip 做 EOCD 兜底完整性校验
     request.allowZipFallbackCheck = YES;
+    retryRequest = request;
 
     [self startPLDownloadWithRequest:request taskItem:taskItem progress:progress completion:completion];
 
@@ -425,7 +410,6 @@
     self.downloadAccumulatedBytes[taskId] = @(0);
     self.downloadTotalBytes[taskId] = @(-1);
     self.downloadLastSpeeds[taskId] = @(0.0);
-    [self.downloadStateLock unlock];
 
     PLDownloadOperation *operation = [[PLDownloadClient sharedClient] startRequest:request
                                                                           progress:^(int64_t deltaBytes, int64_t totalExpectedBytes) {
@@ -445,12 +429,11 @@
     }];
     if (!operation) {
         // 参数错误：PLDownloadClient 会异步回调 completion（error），由统一失败路径收尾
+        [self.downloadStateLock unlock];
         return nil;
     }
 
-    [self.downloadStateLock lock];
     self.downloadOperations[taskId] = operation;
-    [self.downloadStateLock unlock];
 
     // rawTask 为 weak 引用：operation 由 PLDownloadClient 与本 Service 共同持有，
     // DownloadTaskManager 据此对 PLDownloadOperation 做 pause/resume/cancel
@@ -461,6 +444,7 @@
     [[DownloadTaskManager sharedManager] updateTaskWithId:taskId
                                               stageAtIndex:0
                                                   status:PLTaskStageStatusRunning];
+    [self.downloadStateLock unlock];
     return operation;
 }
 
@@ -552,20 +536,20 @@
     [self.downloadStateLock unlock];
 
     DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+    NSError *completionError = success ? nil : (error ?: [NSError errorWithDomain:@"ShaderServiceError" code:3 userInfo:@{NSLocalizedDescriptionKey: @"Shader download failed."}]);
     if (success) {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
-        [manager setTaskWithId:taskId state:DownloadTaskStateCompleted];
+        [manager setTaskWithId:taskId completedWithError:nil];
     } else if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
         // 用户取消（DownloadTaskManager 已置 Cancelled，这里幂等对齐）
         [manager setTaskWithId:taskId state:DownloadTaskStateCancelled];
     } else {
         [manager updateTaskWithId:taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-        [manager updateTaskWithId:taskId error:error];
-        [manager setTaskWithId:taskId state:DownloadTaskStateFailed];
+        [manager setTaskWithId:taskId completedWithError:completionError];
     }
 
     if (completion) {
-        NSError *capturedError = success ? nil : error;
+        NSError *capturedError = completionError;
         dispatch_async(dispatch_get_main_queue(), ^{
             completion(capturedError);
         });

--- a/Natives/ShaderService.m
+++ b/Natives/ShaderService.m
@@ -114,51 +114,26 @@
 }
 
 - (nullable NSString *)existingShadersFolderForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
 
-    // 优先用 profile gameDir（已解析为绝对路径）
-    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profile];
-    if (resolvedGameDir.length > 0) {
-        NSString *shadersPath = [resolvedGameDir stringByAppendingPathComponent:@"shaderpacks"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:shadersPath isDirectory:&isDir] && isDir) {
-            return shadersPath;
-        }
-    }
+    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profileName];
+    if (resolvedGameDir.length == 0) return nil;
 
-    // 回退到 POJAV_GAME_DIR/shaderpacks
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-        NSString *shadersPath = [gameDir stringByAppendingPathComponent:@"shaderpacks"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:shadersPath isDirectory:&isDir] && isDir) {
-            return shadersPath;
-        }
+    NSString *shadersPath = [resolvedGameDir stringByAppendingPathComponent:@"shaderpacks"];
+    BOOL isDir = NO;
+    if ([fm fileExistsAtPath:shadersPath isDirectory:&isDir] && isDir) {
+        return shadersPath;
     }
     return nil;
 }
 
 /// 获取当前 profile 的 shaderpacks 目录，不存在时自动创建
 - (nullable NSString *)ensureShadersFolderForProfile:(NSString *)profileName error:(NSError **)error {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *shadersPath = nil;
-
-    // 优先用 profile gameDir（已解析为绝对路径）
-    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profile];
-    if (resolvedGameDir.length > 0) {
-        shadersPath = [resolvedGameDir stringByAppendingPathComponent:@"shaderpacks"];
-    }
-
-    if (!shadersPath) {
-        const char *gameDirC = getenv("POJAV_GAME_DIR");
-        if (gameDirC) {
-            NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-            shadersPath = [gameDir stringByAppendingPathComponent:@"shaderpacks"];
-        }
-    }
+    NSString *resolvedGameDir = [self resolveAbsoluteGameDirForProfile:profileName];
+    NSString *shadersPath = resolvedGameDir.length > 0
+        ? [resolvedGameDir stringByAppendingPathComponent:@"shaderpacks"]
+        : nil;
 
     if (!shadersPath) {
         if (error) {
@@ -296,9 +271,8 @@
     if (!shadersFolder) {
         // 回退到 ensureShadersFolderForProfile:error:，复用绝对路径解析逻辑
         // （之前直接读 prof[@"gameDir"] 不做相对路径解析，会导致目录创建到错误位置）
-        NSString *profile = profileName.length ? profileName : @"default";
         NSError *dirError = nil;
-        NSString *created = [self ensureShadersFolderForProfile:profile error:&dirError];
+        NSString *created = [self ensureShadersFolderForProfile:profileName error:&dirError];
         if (!created) {
             if (completion) {
                 NSError *error = [NSError errorWithDomain:@"ShaderServiceError"

--- a/Natives/ShaderVersionViewController.h
+++ b/Natives/ShaderVersionViewController.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
 @property (nonatomic, strong) ShaderItem *shaderItem;
 @property (nonatomic, weak) id<ShaderVersionViewControllerDelegate> delegate;
+/// 初始 API 来源：1=Modrinth，2=CurseForge；默认 1。
+@property (nonatomic, assign) NSInteger initialSource;
 
 // FCL 风格：传入当前 profile 的偏好版本和加载器
 // ShaderVersionViewController 会优先选中匹配的 chip，并把匹配的版本置顶

--- a/Natives/ShaderVersionViewController.m
+++ b/Natives/ShaderVersionViewController.m
@@ -102,8 +102,8 @@ static NSArray<NSDictionary *> *SortOptionItems(void) {
     // 适配自定义启动器背景：透明化当前 VC，让全局背景图/毛玻璃透出
     [[BackgroundManager sharedManager] makeViewControllerTransparent:self];
 
-    // 初始化筛选状态（默认 Modrinth 源 + 相关性排序）
-    self.selectedSource = kSourceModrinth;
+    // 从搜索结果继承 API 来源，避免拿 CurseForge 数字 ID 请求 Modrinth。
+    self.selectedSource = self.initialSource == kSourceCurseForge ? kSourceCurseForge : kSourceModrinth;
     self.selectedSort = kSortRelevance;
 
     [self setupSideFilterPanel];

--- a/Natives/ShadersManagerViewController.m
+++ b/Natives/ShadersManagerViewController.m
@@ -10,6 +10,8 @@
 #import "ShaderService.h"
 #import "ShaderItem.h"
 #import "DownloadViewController.h"
+#import "DownloadTaskManager.h"
+#import "PLProfiles.h"
 #import "utils.h"
 
 #pragma mark - ShaderCardCell（光影卡片，Air-Design L2 标准卡片）
@@ -88,6 +90,8 @@ static NSString * const kShaderCardCellIdentifier = @"ShaderCardCell";
 - (void)viewDidLoad {
     [super viewDidLoad]; // 基类完成标题/毛玻璃背景/搜索栏/表格/三态视图/批量工具栏构建
 
+    self.profileName = [PLProfiles effectiveProfileNameForPreferredName:self.profileName];
+
     // 始终使用本地模式（在线下载入口已移至下载界面）
     self.localShaders = [NSMutableArray array];
     self.filteredLocalShaders = [NSMutableArray array];
@@ -108,7 +112,14 @@ static NSString * const kShaderCardCellIdentifier = @"ShaderCardCell";
     self.tableView.refreshControl = refreshControl;
 
     [self setupNavigationButtons];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDownloadTaskCompleted:)
+                                                 name:DownloadTaskManagerTaskCompletedNotification
+                                               object:nil];
+}
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [self refreshLocalShadersList];
 }
 
@@ -405,6 +416,7 @@ static NSString * const kShaderCardCellIdentifier = @"ShaderCardCell";
     // 跳转统一下载界面并定位到光影 tab（在线下载入口已统一收口到下载页）
     DownloadViewController *downloadVC = [[DownloadViewController alloc] init];
     downloadVC.initialTabIndex = 2; // 0版本 1模组 2光影
+    downloadVC.targetProfileName = self.profileName;
     if (self.navigationController) {
         [self.navigationController pushViewController:downloadVC animated:YES];
     } else {
@@ -413,6 +425,14 @@ static NSString * const kShaderCardCellIdentifier = @"ShaderCardCell";
         nav.modalPresentationStyle = UIModalPresentationFullScreen;
         [self presentViewController:nav animated:YES completion:nil];
     }
+}
+
+- (void)handleDownloadTaskCompleted:(NSNotification *)notification {
+    DownloadTaskItem *task = notification.userInfo[DownloadTaskManagerTaskKey];
+    if (task.state != DownloadTaskStateCompleted ||
+        ![task.resourceType isEqualToString:DownloadTaskResourceTypeShader] ||
+        ![task.userInfo[@"profileName"] isEqualToString:self.profileName]) return;
+    [self refreshLocalShadersList];
 }
 
 #pragma mark - 搜索（UISearchBarDelegate）

--- a/Natives/VersionManagerViewController.m
+++ b/Natives/VersionManagerViewController.m
@@ -1136,12 +1136,7 @@ static NSInteger const kSectionVersions    = 1;
 /// 获取当前选中 profile 的渲染器（如未设置则回退到全局偏好）
 - (NSString *)currentRendererForSelectedProfile {
     if (!self.selectedProfile) return @"auto";
-    NSDictionary *profile = PLProfiles.current.profiles[self.selectedProfile];
-    NSString *r = profile[@"renderer"];
-    if (r.length == 0) {
-        r = getPrefObject(@"video.renderer");
-    }
-    return r.length > 0 ? r : @"auto";
+    return [PLProfiles profile:PLProfiles.current.profiles[self.selectedProfile] resolveKey:@"renderer"] ?: @"auto";
 }
 
 /// 获取当前选中 profile 的图形 API（MC 26.2+，如未设置则回退到全局偏好，再回退到 default）
@@ -1592,9 +1587,6 @@ static NSInteger const kSectionVersions    = 1;
     profiles[self.selectedProfile] = profile;
     [PLProfiles.current save];
 
-    // 同步到全局偏好（保证启动游戏时 LauncherRightPanelViewController 能读到）
-    setPrefString(@"video.renderer", key);
-
     [self.collectionView reloadData];
 
     NSLog(@"[VersionMgr] Renderer for profile '%@' set to '%@' (%@)", self.selectedProfile, key, displayName);
@@ -1627,9 +1619,6 @@ static NSInteger const kSectionVersions    = 1;
     profile[@"graphicsApi"] = key;
     profiles[self.selectedProfile] = profile;
     [PLProfiles.current save];
-
-    // 同步到全局偏好
-    setPrefString(@"video.graphics_api", key);
 
     [self.collectionView reloadData];
 

--- a/Natives/WorldItem.h
+++ b/Natives/WorldItem.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // --- 在线世界属性（用于在线下载） ---
 @property (nonatomic, copy, nullable) NSString *onlineID;
+/// 在线 API 来源：1=Modrinth，2=CurseForge。
+@property (nonatomic, assign) NSInteger apiSource;
 @property (nonatomic, copy, nullable) NSString *author;
 @property (nonatomic, strong, nullable) NSNumber *downloads;
 @property (nonatomic, strong, nullable) NSNumber *likes;

--- a/Natives/WorldItem.m
+++ b/Natives/WorldItem.m
@@ -42,6 +42,7 @@
     if (self = [super init]) {
         // 来自 Modrinth/CurseForge 搜索结果
         _onlineID = data[@"id"] ? [data[@"id"] description] : nil;
+        _apiSource = [data[@"apiSource"] integerValue] == 2 ? 2 : 1;
         _displayName = data[@"title"] ?: @"";
         _worldDescription = data[@"description"] ?: @"";
         _iconURL = data[@"imageUrl"] ?: @"";

--- a/Natives/WorldService.h
+++ b/Natives/WorldService.h
@@ -26,7 +26,7 @@ typedef void(^WorldDownloadProgressHandler)(NSProgress * _Nullable downloadProgr
 
 // --- 本地世界管理 ---
 // 扫描指定 profile 的 saves 目录，返回每个含 level.dat 的子目录作为一个 WorldItem
-- (void)scanWorldsForProfile:(NSString *)profileName completion:(WorldListHandler)completion;
+- (void)scanWorldsForProfile:(NSString * _Nullable)profileName completion:(WorldListHandler)completion;
 // 删除世界目录（递归删除）
 - (BOOL)deleteWorld:(WorldItem *)item error:(NSError **)error;
 
@@ -35,24 +35,24 @@ typedef void(^WorldDownloadProgressHandler)(NSProgress * _Nullable downloadProgr
 // progress 回调实时上报下载进度（不含解压阶段）
 // completion 在主线程回调，success 表示下载并解压是否成功
 - (void)downloadWorld:(WorldItem *)item
-            toProfile:(NSString *)profileName
+            toProfile:(NSString * _Nullable)profileName
              progress:(WorldDownloadProgressHandler _Nullable)progress
            completion:(WorldDownloadCompletionHandler _Nullable)completion;
 
 // 从本地文件 URL 导入世界 zip（如 UIDocumentPicker 选择的文件）
 // 同样做健壮解压，导入完成后可删除临时 zip
 - (void)importWorldFromURL:(NSURL *)sourceURL
-                toProfile:(NSString *)profileName
+                toProfile:(NSString * _Nullable)profileName
                  progress:(WorldDownloadProgressHandler _Nullable)progress
                completion:(WorldDownloadCompletionHandler _Nullable)completion;
 
 // --- 工具方法 ---
 
 /// 获取当前 profile 的 saves 目录，不存在时自动创建
-- (nullable NSString *)ensureWorldsFolderForProfile:(NSString *)profileName error:(NSError **)error;
+- (nullable NSString *)ensureWorldsFolderForProfile:(NSString * _Nullable)profileName error:(NSError **)error;
 
 /// 查找当前 profile 的 saves 目录（已存在时返回路径，否则返回 nil）
-- (nullable NSString *)existingWorldsFolderForProfile:(NSString *)profileName;
+- (nullable NSString *)existingWorldsFolderForProfile:(NSString * _Nullable)profileName;
 
 @end
 

--- a/Natives/WorldService.m
+++ b/Natives/WorldService.m
@@ -21,12 +21,26 @@
 #import "LauncherPreferences.h"
 
 static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration";
+static NSString * const PLWorldStagingRootName = @".amethyst-world-staging";
+static NSString * const PLWorldArchiveFileName = @"world.zip";
+
+@interface PLStagedWorld : NSObject
+@property (nonatomic, copy) NSString *stagingDirectory;
+@property (nonatomic, copy) NSString *worldDirectory;
+@property (nonatomic, copy) NSString *suggestedName;
+@end
+
+@implementation PLStagedWorld
+@end
 
 @interface WorldService () <NSURLSessionDownloadDelegate>
 @property (nonatomic, strong) NSURLSession *downloadSession;
 // 内部统一存储带 success/error 的 completion handler
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, WorldDownloadCompletionHandler> *downloadCompletionHandlers;
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSString *> *downloadDestinationPaths;
+@property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSString *> *downloadStagingDirectories;
+@property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSString *> *downloadWorldNames;
+@property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSString *> *downloadSavesFolders;
 // 进度回调相关：分别保存进度 handler 和 NSProgress 对象
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, WorldDownloadProgressHandler> *downloadProgressHandlers;
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSProgress *> *downloadProgresses;
@@ -60,6 +74,9 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
         _downloadSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
         _downloadCompletionHandlers = [NSMutableDictionary dictionary];
         _downloadDestinationPaths = [NSMutableDictionary dictionary];
+        _downloadStagingDirectories = [NSMutableDictionary dictionary];
+        _downloadWorldNames = [NSMutableDictionary dictionary];
+        _downloadSavesFolders = [NSMutableDictionary dictionary];
         _downloadProgressHandlers = [NSMutableDictionary dictionary];
         _downloadProgresses = [NSMutableDictionary dictionary];
         _downloadTaskItems = [NSMutableDictionary dictionary];
@@ -82,7 +99,9 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
 // 查找指定 profile 的 saves 目录（已存在时返回路径，否则返回 nil）
 - (nullable NSString *)existingWorldsFolderForProfile:(NSString *)profileName {
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *savesPath = [[self gameDirForProfile:profileName] stringByAppendingPathComponent:@"saves"];
+    NSString *gameDir = [self gameDirForProfile:profileName];
+    if (gameDir.length == 0) return nil;
+    NSString *savesPath = [gameDir stringByAppendingPathComponent:@"saves"];
     BOOL isDir = NO;
     if ([fm fileExistsAtPath:savesPath isDirectory:&isDir] && isDir) return savesPath;
     return nil;
@@ -180,143 +199,294 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
 
 #pragma mark - 健壮解压逻辑
 
-// 检测 zip 内是否存在顶层目录（即所有条目都以同一个目录名开头）
-// 若存在，返回该顶层目录名；否则返回 nil（说明 zip 直接散装了 level.dat 等文件）
-- (nullable NSString *)detectTopLevelDirectoryInZip:(NSString *)zipPath {
-    NSError *err = nil;
-    UZKArchive *archive = [[UZKArchive alloc] initWithPath:zipPath error:&err];
-    if (!archive || err) return nil;
-
-    NSArray<NSString *> *fileNames = [archive listFilenames:&err];
-    if (!fileNames || fileNames.count == 0) return nil;
-
-    NSMutableSet<NSString *> *topLevels = [NSMutableSet set];
-    for (NSString *name in fileNames) {
-        if (name.length == 0) continue;
-        // 跳过 macOS 元数据文件（如 __MACOSX/...）
-        if ([name hasPrefix:@"__MACOSX/"]) continue;
-        // 取第一段作为顶层目录候选
-        NSString *firstComponent = [name componentsSeparatedByString:@"/"].firstObject;
-        if (firstComponent.length == 0) continue;
-        [topLevels addObject:firstComponent];
+// 每次下载/导入使用 saves 同级的唯一 staging。它与 saves 位于同一卷，最终
+// moveItemAtPath: 可安全 rename，同时任何解压失败都不会触碰已有世界。
+- (nullable NSString *)createWorldStagingDirectoryForSavesDir:(NSString *)savesDir
+                                                         error:(NSError **)error {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *gameDirectory = savesDir.stringByDeletingLastPathComponent;
+    NSString *stagingRoot = [gameDirectory stringByAppendingPathComponent:PLWorldStagingRootName];
+    BOOL isDirectory = NO;
+    if ([fm fileExistsAtPath:stagingRoot isDirectory:&isDirectory]) {
+        if (!isDirectory) {
+            if (error) {
+                *error = [NSError errorWithDomain:@"WorldServiceError"
+                                             code:8
+                                         userInfo:@{NSLocalizedDescriptionKey: @"The world staging path is not a directory."}];
+            }
+            return nil;
+        }
+    } else if (![fm createDirectoryAtPath:stagingRoot
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:error]) {
+        return nil;
     }
 
-    // 仅当所有条目共享同一个顶层目录时，才认为 zip 内有顶层目录
-    if (topLevels.count == 1) {
-        return [topLevels anyObject];
+    NSString *stagingDirectory = [stagingRoot stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
+    if (![fm createDirectoryAtPath:stagingDirectory
+       withIntermediateDirectories:NO
+                        attributes:nil
+                             error:error]) {
+        return nil;
     }
-    return nil;
+    return stagingDirectory.stringByStandardizingPath;
 }
 
-// 健壮解压：
-// - 若 zip 内有顶层目录，直接解压到 saves/
-// - 若 zip 内无顶层目录（散装），先用世界名创建子目录，再解压到该子目录
-// - worldName 用于无顶层目录时命名新世界目录
-- (nullable NSString *)worldDirectoryContainingLevelDatUnderPath:(NSString *)rootPath {
-    NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *directLevelDat = [rootPath stringByAppendingPathComponent:@"level.dat"];
-    if ([fm fileExistsAtPath:directLevelDat]) return rootPath;
-
-    NSDirectoryEnumerator<NSString *> *enumerator = [fm enumeratorAtPath:rootPath];
-    for (NSString *relativePath in enumerator) {
-        if ([[relativePath lastPathComponent] isEqualToString:@"level.dat"]) {
-            return [[rootPath stringByAppendingPathComponent:relativePath] stringByDeletingLastPathComponent];
-        }
+- (void)cleanupWorldStagingDirectory:(nullable NSString *)stagingDirectory {
+    if (stagingDirectory.length == 0) return;
+    NSString *standardPath = stagingDirectory.stringByStandardizingPath;
+    NSString *parentName = standardPath.stringByDeletingLastPathComponent.lastPathComponent;
+    if (![parentName isEqualToString:PLWorldStagingRootName] || standardPath.lastPathComponent.length == 0) {
+        NSLog(@"[WorldService] refusing to remove unexpected staging path: %@", stagingDirectory);
+        return;
     }
-    return nil;
+    [[NSFileManager defaultManager] removeItemAtPath:standardPath error:nil];
 }
 
-- (BOOL)extractWorldZipAt:(NSString *)zipPath
-                toSavesDir:(NSString *)savesDir
-                worldName:(NSString *)worldName
-                    error:(NSError **)error {
-    NSFileManager *fm = [NSFileManager defaultManager];
-
-    NSString *topLevelDir = [self detectTopLevelDirectoryInZip:zipPath];
-    NSString *extractTargetDir = nil;
-    NSString *finalWorldDir = nil;
-    BOOL finalWorldDirExistedBefore = NO;
-
-    if (topLevelDir) {
-        // zip 内有顶层目录，直接解压到 saves/
-        extractTargetDir = savesDir;
-        finalWorldDir = [savesDir stringByAppendingPathComponent:topLevelDir];
-        finalWorldDirExistedBefore = [fm fileExistsAtPath:finalWorldDir];
-    } else {
-        // zip 内无顶层目录，需要创建子目录后再解压
-        NSString *baseName = worldName.length > 0 ? worldName : [zipPath lastPathComponent];
-        // 去除可能的 .zip 后缀
-        if ([baseName.lowercaseString hasSuffix:@".zip"]) {
-            baseName = [baseName substringToIndex:baseName.length - @".zip".length];
+- (BOOL)archiveEntries:(NSArray<NSString *> *)entries
+  areSafeUnderDirectory:(NSString *)directory
+                  error:(NSError **)error {
+    NSString *root = directory.stringByStandardizingPath;
+    NSString *rootPrefix = [root stringByAppendingString:@"/"];
+    for (id rawEntry in entries) {
+        if (![rawEntry isKindOfClass:[NSString class]]) continue;
+        NSString *entry = [(NSString *)rawEntry stringByReplacingOccurrencesOfString:@"\\" withString:@"/"];
+        if (entry.length == 0) continue;
+        NSArray<NSString *> *components = [entry componentsSeparatedByString:@"/"];
+        if ([entry hasPrefix:@"/"] || [components containsObject:@".."]) {
+            if (error) {
+                *error = [NSError errorWithDomain:@"WorldServiceError"
+                                             code:9
+                                         userInfo:@{NSLocalizedDescriptionKey: @"The world archive contains an unsafe path."}];
+            }
+            return NO;
         }
-        // 若 saves/<baseName> 已存在，则追加数字后缀避免覆盖
-        NSString *candidate = [savesDir stringByAppendingPathComponent:baseName];
-        NSInteger suffix = 1;
-        while ([fm fileExistsAtPath:candidate]) {
-            candidate = [savesDir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%ld", baseName, (long)suffix]];
-            suffix++;
-        }
-        extractTargetDir = candidate;
-        finalWorldDir = candidate;
-
-        // 创建目标子目录
-        NSError *createError = nil;
-        if (![fm createDirectoryAtPath:extractTargetDir withIntermediateDirectories:YES attributes:nil error:&createError]) {
-            if (error) *error = createError;
+        NSString *candidate = [[root stringByAppendingPathComponent:entry] stringByStandardizingPath];
+        if (![candidate isEqualToString:root] && ![candidate hasPrefix:rootPrefix]) {
+            if (error) {
+                *error = [NSError errorWithDomain:@"WorldServiceError"
+                                             code:9
+                                         userInfo:@{NSLocalizedDescriptionKey: @"The world archive contains an unsafe path."}];
+            }
             return NO;
         }
     }
+    return YES;
+}
 
-    // 使用 UnzipKit 解压到目标目录
-    NSError *archiveError = nil;
-    UZKArchive *archive = [[UZKArchive alloc] initWithPath:zipPath error:&archiveError];
-    if (!archive || archiveError) {
-        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
-        if (error) *error = archiveError;
-        return NO;
+// 找到唯一的最浅层世界根目录。压缩包可有任意层 wrapper，但多个同层世界
+// 属于歧义输入，不能依赖目录枚举顺序任意安装其中一个。
+- (nullable NSString *)worldDirectoryContainingLevelDatUnderPath:(NSString *)rootPath
+                                                             error:(NSError **)error {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *root = rootPath.stringByStandardizingPath;
+    NSString *rootPrefix = [root stringByAppendingString:@"/"];
+    NSMutableDictionary<NSString *, NSNumber *> *candidates = [NSMutableDictionary dictionary];
+    NSDirectoryEnumerator<NSString *> *enumerator = [fm enumeratorAtPath:root];
+
+    for (NSString *relativePath in enumerator) {
+        NSString *fullPath = [[root stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
+        if (![fullPath hasPrefix:rootPrefix]) {
+            if (error) {
+                *error = [NSError errorWithDomain:@"WorldServiceError"
+                                             code:9
+                                         userInfo:@{NSLocalizedDescriptionKey: @"The extracted world escaped its staging directory."}];
+            }
+            return nil;
+        }
+
+        NSError *attributeError = nil;
+        NSDictionary *attributes = [fm attributesOfItemAtPath:fullPath error:&attributeError];
+        if (attributeError) {
+            if (error) *error = attributeError;
+            return nil;
+        }
+        if ([attributes[NSFileType] isEqualToString:NSFileTypeSymbolicLink]) {
+            if (error) {
+                *error = [NSError errorWithDomain:@"WorldServiceError"
+                                             code:9
+                                         userInfo:@{NSLocalizedDescriptionKey: @"The world archive contains a symbolic link."}];
+            }
+            return nil;
+        }
+        if (![relativePath.lastPathComponent isEqualToString:@"level.dat"] ||
+            [[relativePath pathComponents] containsObject:@"__MACOSX"]) {
+            continue;
+        }
+        if (![attributes[NSFileType] isEqualToString:NSFileTypeRegular]) continue;
+
+        NSString *worldDirectory = fullPath.stringByDeletingLastPathComponent;
+        NSString *relativeWorld = [worldDirectory isEqualToString:root]
+            ? @""
+            : [worldDirectory substringFromIndex:rootPrefix.length];
+        NSUInteger depth = relativeWorld.length == 0 ? 0 : relativeWorld.pathComponents.count;
+        candidates[worldDirectory] = @(depth);
     }
 
-    NSError *extractError = nil;
-    BOOL success = [archive extractFilesTo:extractTargetDir overwrite:YES error:&extractError];
-    if (!success || extractError) {
-        if (error) *error = extractError;
-        // 仅清理本次新建的世界目录，保留下载前已经存在的用户数据。
-        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
-        return NO;
-    }
-
-    // Minecraft 只识别 saves/ 的直接子目录。若压缩包多套了一层目录，找到真正
-    // 包含 level.dat 的目录并提升到 saves/，否则管理页和游戏都会把它当作不存在。
-    NSString *actualWorldDir = [self worldDirectoryContainingLevelDatUnderPath:finalWorldDir];
-    if (!actualWorldDir) {
-        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
+    if (candidates.count == 0) {
         if (error) {
             *error = [NSError errorWithDomain:@"WorldServiceError"
                                          code:7
                                      userInfo:@{NSLocalizedDescriptionKey: @"The downloaded archive does not contain a valid Minecraft world (level.dat is missing)."}];
         }
-        return NO;
+        return nil;
     }
 
-    if (![actualWorldDir isEqualToString:finalWorldDir]) {
-        NSString *baseName = actualWorldDir.lastPathComponent.length > 0 ? actualWorldDir.lastPathComponent : worldName;
-        NSString *promotedWorldDir = [savesDir stringByAppendingPathComponent:baseName];
-        NSInteger suffix = 1;
-        while ([fm fileExistsAtPath:promotedWorldDir]) {
-            promotedWorldDir = [savesDir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%ld", baseName, (long)suffix++]];
+    NSUInteger minimumDepth = NSUIntegerMax;
+    for (NSNumber *depth in candidates.allValues) minimumDepth = MIN(minimumDepth, depth.unsignedIntegerValue);
+    NSArray<NSString *> *shallowest = [candidates keysOfEntriesPassingTest:^BOOL(NSString *key, NSNumber *depth, BOOL *stop) {
+        return depth.unsignedIntegerValue == minimumDepth;
+    }].allObjects;
+    if (shallowest.count != 1) {
+        if (error) {
+            *error = [NSError errorWithDomain:@"WorldServiceError"
+                                         code:10
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The world archive contains multiple ambiguous worlds."}];
         }
+        return nil;
+    }
+    return shallowest.firstObject;
+}
+
+- (NSString *)sanitizedWorldDirectoryName:(nullable NSString *)preferredName {
+    NSString *normalized = [(preferredName ?: @"") stringByReplacingOccurrencesOfString:@"\\" withString:@"/"];
+    NSString *name = [normalized.lastPathComponent stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if ([name.lowercaseString hasSuffix:@".zip"]) {
+        name = [name substringToIndex:name.length - @".zip".length];
+    }
+    name = [[name componentsSeparatedByCharactersInSet:NSCharacterSet.controlCharacterSet] componentsJoinedByString:@"_"];
+    if (name.length == 0 || [name isEqualToString:@"."] || [name isEqualToString:@".."]) {
+        return @"imported_world";
+    }
+    return name;
+}
+
+- (nullable PLStagedWorld *)stageWorldZipAt:(NSString *)zipPath
+                           stagingDirectory:(NSString *)stagingDirectory
+                                  worldName:(NSString *)worldName
+                                      error:(NSError **)error {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *staging = stagingDirectory.stringByStandardizingPath;
+    NSString *stagingPrefix = [staging stringByAppendingString:@"/"];
+    NSString *archivePath = zipPath.stringByStandardizingPath;
+    if (![archivePath hasPrefix:stagingPrefix]) {
+        if (error) {
+            *error = [NSError errorWithDomain:@"WorldServiceError"
+                                         code:9
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The world archive is outside its staging directory."}];
+        }
+        return nil;
+    }
+
+    NSError *archiveError = nil;
+    UZKArchive *archive = [[UZKArchive alloc] initWithPath:archivePath error:&archiveError];
+    NSArray<NSString *> *entries = archive ? [archive listFilenames:&archiveError] : nil;
+    if (!archive || archiveError || entries.count == 0) {
+        if (error) *error = archiveError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                code:5
+                                                            userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}];
+        return nil;
+    }
+
+    NSString *extractDirectory = [staging stringByAppendingPathComponent:@"extracted"];
+    if (![self archiveEntries:entries areSafeUnderDirectory:extractDirectory error:error]) return nil;
+    if (![fm createDirectoryAtPath:extractDirectory
+       withIntermediateDirectories:NO
+                        attributes:nil
+                             error:error]) {
+        return nil;
+    }
+
+    NSError *extractError = nil;
+    if (![archive extractFilesTo:extractDirectory overwrite:NO error:&extractError] || extractError) {
+        if (error) *error = extractError;
+        return nil;
+    }
+
+    NSString *worldDirectory = [self worldDirectoryContainingLevelDatUnderPath:extractDirectory error:error];
+    if (!worldDirectory) return nil;
+
+    PLStagedWorld *stagedWorld = [[PLStagedWorld alloc] init];
+    stagedWorld.stagingDirectory = staging;
+    stagedWorld.worldDirectory = worldDirectory;
+    stagedWorld.suggestedName = [self sanitizedWorldDirectoryName:
+        [worldDirectory isEqualToString:extractDirectory] ? worldName : worldDirectory.lastPathComponent];
+    return stagedWorld;
+}
+
+- (nullable NSString *)commitStagedWorld:(PLStagedWorld *)stagedWorld
+                              toSavesDir:(NSString *)savesDir
+                                   error:(NSError **)error {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *staging = stagedWorld.stagingDirectory.stringByStandardizingPath;
+    NSString *source = stagedWorld.worldDirectory.stringByStandardizingPath;
+    NSString *stagingPrefix = [staging stringByAppendingString:@"/"];
+    if (![source hasPrefix:stagingPrefix]) {
+        if (error) {
+            *error = [NSError errorWithDomain:@"WorldServiceError"
+                                         code:9
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The staged world is outside its staging directory."}];
+        }
+        return nil;
+    }
+
+    NSString *levelDat = [source stringByAppendingPathComponent:@"level.dat"];
+    NSDictionary *attributes = [fm attributesOfItemAtPath:levelDat error:error];
+    if (![attributes[NSFileType] isEqualToString:NSFileTypeRegular]) {
+        if (error && !*error) {
+            *error = [NSError errorWithDomain:@"WorldServiceError"
+                                         code:7
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The staged world does not contain a regular level.dat file."}];
+        }
+        return nil;
+    }
+
+    NSString *baseName = [self sanitizedWorldDirectoryName:stagedWorld.suggestedName];
+    for (NSInteger suffix = 0; suffix < 10000; suffix++) {
+        NSString *candidateName = suffix == 0
+            ? baseName
+            : [NSString stringWithFormat:@"%@_%ld", baseName, (long)suffix];
+        NSString *destination = [savesDir stringByAppendingPathComponent:candidateName];
+        if ([fm fileExistsAtPath:destination]) continue;
 
         NSError *moveError = nil;
-        if (![fm moveItemAtPath:actualWorldDir toPath:promotedWorldDir error:&moveError]) {
-            if (error) *error = moveError;
-            return NO;
+        if ([fm moveItemAtPath:source toPath:destination error:&moveError]) {
+            NSString *installedLevelDat = [destination stringByAppendingPathComponent:@"level.dat"];
+            NSDictionary *installedAttributes = [fm attributesOfItemAtPath:installedLevelDat error:&moveError];
+            if ([installedAttributes[NSFileType] isEqualToString:NSFileTypeRegular]) {
+                NSLog(@"[WorldService] staged world committed to: %@", destination);
+                return destination;
+            }
+            [fm removeItemAtPath:destination error:nil];
+            if (error) *error = moveError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                  code:7
+                                                              userInfo:@{NSLocalizedDescriptionKey: @"The installed world failed level.dat validation."}];
+            return nil;
         }
-        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
-        finalWorldDir = promotedWorldDir;
+
+        // 两个并发导入可能同时选择同一名字。目标刚被占用时换下一个后缀；
+        // 其他移动错误直接返回，绝不删除或覆盖目标目录。
+        if ([fm fileExistsAtPath:destination]) continue;
+        if (error) *error = moveError;
+        return nil;
     }
 
-    NSLog(@"[WorldService] world extracted to: %@", finalWorldDir);
-    return YES;
+    if (error) {
+        *error = [NSError errorWithDomain:@"WorldServiceError"
+                                     code:11
+                                 userInfo:@{NSLocalizedDescriptionKey: @"Unable to allocate a unique world directory name."}];
+    }
+    return nil;
+}
+
+- (BOOL)isWorldTaskItemCurrent:(nullable DownloadTaskItem *)taskItem
+                     generation:(NSNumber *)generation {
+    if (!taskItem || !generation) return NO;
+    DownloadTaskItem *latestTask = [[DownloadTaskManager sharedManager] taskWithId:taskItem.taskId];
+    return latestTask != nil &&
+           latestTask.state == DownloadTaskStateDownloading &&
+           [latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation];
 }
 
 #pragma mark - 在线世界下载（含健壮解压）
@@ -350,17 +520,25 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
         return;
     }
 
-    // 下载到临时 zip 路径，解压后再删除
-    NSString *tempZipName = [NSString stringWithFormat:@"world_%@.zip", [[NSUUID UUID] UUIDString]];
-    NSString *destinationPath = [NSTemporaryDirectory() stringByAppendingPathComponent:tempZipName];
+    // 下载到 saves 同卷的唯一 staging。任何下载、解压或验证失败都只清理该目录，
+    // 不会把压缩包内容直接写入已有世界。
+    NSError *stagingError = nil;
+    NSString *stagingDirectory = [self createWorldStagingDirectoryForSavesDir:savesFolder error:&stagingError];
+    if (!stagingDirectory) {
+        if (completion) {
+            NSError *error = stagingError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                  code:8
+                                                              userInfo:@{NSLocalizedDescriptionKey: @"Unable to create world staging directory."}];
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(NO, error); });
+        }
+        return;
+    }
+    NSString *destinationPath = [stagingDirectory stringByAppendingPathComponent:PLWorldArchiveFileName];
     // 同时记录预期世界名（用于无顶层目录时的子目录命名）
     NSString *worldNameForExtract = item.displayName ?: item.worldName ?: [url lastPathComponent];
 
     // 创建下载任务（默认会话配置，无后台限速）
     NSURLSessionDownloadTask *task = [self.downloadSession downloadTaskWithURL:url];
-    // 用 taskDescription 暂存世界名和 saves 目录（用于解压阶段）
-    // 格式："worldName\nsavesFolder"
-    task.taskDescription = [NSString stringWithFormat:@"%@\n%@", worldNameForExtract, savesFolder];
     NSProgress *progressObj = nil;
     if (progress) {
         progressObj = [NSProgress progressWithTotalUnitCount:-1];
@@ -383,6 +561,7 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
     NSString *taskProfileName = [PLProfiles effectiveProfileNameForPreferredName:profileName];
     if (taskProfileName.length > 0) taskItem.userInfo[@"profileName"] = taskProfileName;
     taskItem.userInfo[@"destinationPath"] = destinationPath;
+    taskItem.userInfo[@"stagingDirectory"] = stagingDirectory;
     taskItem.userInfo[PLWorldDownloadGenerationKey] = @(task.taskIdentifier);
     // 世界暂停恢复需要用新的 NSURLSessionTask 从头重建，不应消耗网络失败重试预算。
     taskItem.maxRetryCount = 0;
@@ -390,6 +569,9 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
     [self.downloadStateLock lock];
     if (completion) self.downloadCompletionHandlers[task] = completion;
     self.downloadDestinationPaths[task] = destinationPath;
+    self.downloadStagingDirectories[task] = stagingDirectory;
+    self.downloadWorldNames[task] = worldNameForExtract;
+    self.downloadSavesFolders[task] = savesFolder;
     if (progressObj) self.downloadProgresses[task] = progressObj;
     if (progress) self.downloadProgressHandlers[task] = progress;
     self.downloadTaskItems[task] = taskItem;
@@ -400,8 +582,8 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
 
     // 设置 retryHandler：FCL 风格重新下载
     __weak typeof(self) weakSelf = self;
-    NSString *capturedDestPath = destinationPath;
-    NSString *capturedTaskDescription = task.taskDescription;
+    NSString *capturedWorldName = worldNameForExtract;
+    NSString *capturedSavesFolder = savesFolder;
     WorldDownloadCompletionHandler capturedCompletion = completion;
     void (^capturedProgress)(NSProgress *) = progress;
     taskItem.retryHandler = ^id(DownloadTaskItem *taskItemRef) {
@@ -409,14 +591,30 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
         if (!strongSelf) return nil;
         NSURL *retryURL = [NSURL URLWithString:taskItemRef.downloadURL] ?: url;
         if (!retryURL) return nil;
+        NSError *retryStagingError = nil;
+        NSString *retryStagingDirectory = [strongSelf createWorldStagingDirectoryForSavesDir:capturedSavesFolder
+                                                                                        error:&retryStagingError];
+        if (!retryStagingDirectory) {
+            NSError *finalError = retryStagingError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                            code:8
+                                                                        userInfo:@{NSLocalizedDescriptionKey: @"Unable to create world staging directory."}];
+            [[DownloadTaskManager sharedManager] setTaskWithId:taskItemRef.taskId completedWithError:finalError];
+            return nil;
+        }
+        NSString *retryDestinationPath = [retryStagingDirectory stringByAppendingPathComponent:PLWorldArchiveFileName];
         NSURLSessionDownloadTask *newTask = [strongSelf.downloadSession downloadTaskWithURL:retryURL];
-        newTask.taskDescription = capturedTaskDescription;
         taskItemRef.userInfo[PLWorldDownloadGenerationKey] = @(newTask.taskIdentifier);
+        taskItemRef.userInfo[@"destinationPath"] = retryDestinationPath;
+        taskItemRef.userInfo[@"stagingDirectory"] = retryStagingDirectory;
+        taskItemRef.supportsResume = YES;
         // manager 随后依据 rawTask 获取并发槽；必须在切换 Downloading 前写入。
         taskItemRef.rawTask = newTask;
         [strongSelf.downloadStateLock lock];
         if (capturedCompletion) strongSelf.downloadCompletionHandlers[newTask] = capturedCompletion;
-        strongSelf.downloadDestinationPaths[newTask] = capturedDestPath;
+        strongSelf.downloadDestinationPaths[newTask] = retryDestinationPath;
+        strongSelf.downloadStagingDirectories[newTask] = retryStagingDirectory;
+        strongSelf.downloadWorldNames[newTask] = capturedWorldName;
+        strongSelf.downloadSavesFolders[newTask] = capturedSavesFolder;
         if (capturedProgress) {
             NSProgress *progressObj = [NSProgress progressWithTotalUnitCount:-1];
             progressObj.kind = NSProgressKindFile;
@@ -463,6 +661,7 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
             needsStopAccessing = [sourceURL startAccessingSecurityScopedResource];
         }
 
+        __block NSString *stagingDirectory = nil;
         @try {
             NSString *sourcePath = sourceURL.path;
             if (!sourcePath || ![[NSFileManager defaultManager] fileExistsAtPath:sourcePath]) {
@@ -475,11 +674,23 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
                 return;
             }
 
-            // 复制到临时文件以便 UnzipKit 安全读取（避免安全作用域限制）
-            NSString *tempZipPath = [NSTemporaryDirectory() stringByAppendingPathComponent:
-                                     [NSString stringWithFormat:@"world_import_%@.zip", [[NSUUID UUID] UUIDString]]];
+            NSError *stagingError = nil;
+            stagingDirectory = [self createWorldStagingDirectoryForSavesDir:savesFolder error:&stagingError];
+            if (!stagingDirectory) {
+                if (completion) {
+                    NSError *error = stagingError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                          code:8
+                                                                      userInfo:@{NSLocalizedDescriptionKey: @"Unable to create world staging directory."}];
+                    dispatch_async(dispatch_get_main_queue(), ^{ completion(NO, error); });
+                }
+                return;
+            }
+
+            // 复制进唯一 staging 后再读取，既保持 security-scoped URL 生命周期安全，
+            // 也确保后续解压和最终 rename 都不接触现有世界。
+            NSString *stagedZipPath = [stagingDirectory stringByAppendingPathComponent:PLWorldArchiveFileName];
             NSError *copyError = nil;
-            if (![[NSFileManager defaultManager] copyItemAtPath:sourcePath toPath:tempZipPath error:&copyError]) {
+            if (![[NSFileManager defaultManager] copyItemAtPath:sourcePath toPath:stagedZipPath error:&copyError]) {
                 if (completion) {
                     NSError *error = copyError ?: [NSError errorWithDomain:@"WorldServiceError"
                                                                        code:4
@@ -489,41 +700,40 @@ static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration
                 return;
             }
 
-            // 本地导入可直接上报 100% 进度（无网络下载阶段）
-            if (progress) {
-                NSProgress *prog = [NSProgress progressWithTotalUnitCount:1];
-                prog.completedUnitCount = 1;
-                dispatch_async(dispatch_get_main_queue(), ^{ progress(prog); });
-            }
-
             // 推导世界名（去除 .zip 后缀）
             NSString *worldName = [sourceURL lastPathComponent];
             if ([worldName.lowercaseString hasSuffix:@".zip"]) {
                 worldName = [worldName substringToIndex:worldName.length - @".zip".length];
             }
 
-            // 解压
-            NSError *extractError = nil;
-            BOOL success = [self extractWorldZipAt:tempZipPath
-                                        toSavesDir:savesFolder
-                                        worldName:worldName
-                                            error:&extractError];
+            NSError *installError = nil;
+            PLStagedWorld *stagedWorld = [self stageWorldZipAt:stagedZipPath
+                                             stagingDirectory:stagingDirectory
+                                                    worldName:worldName
+                                                        error:&installError];
+            NSString *installedWorldPath = stagedWorld
+                ? [self commitStagedWorld:stagedWorld toSavesDir:savesFolder error:&installError]
+                : nil;
+            BOOL success = installedWorldPath.length > 0;
 
-            // 删除临时文件
-            [[NSFileManager defaultManager] removeItemAtPath:tempZipPath error:nil];
-
-            if (completion) {
+            if (completion || (success && progress)) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     if (success) {
-                        completion(YES, nil);
-                    } else {
-                        completion(NO, extractError ?: [NSError errorWithDomain:@"WorldServiceError"
+                        if (progress) {
+                            NSProgress *prog = [NSProgress progressWithTotalUnitCount:1];
+                            prog.completedUnitCount = 1;
+                            progress(prog);
+                        }
+                        if (completion) completion(YES, nil);
+                    } else if (completion) {
+                        completion(NO, installError ?: [NSError errorWithDomain:@"WorldServiceError"
                                                                             code:5
                                                                         userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}]);
                     }
                 });
             }
         } @finally {
+            [self cleanupWorldStagingDirectory:stagingDirectory];
             if (needsStopAccessing) {
                 [sourceURL stopAccessingSecurityScopedResource];
             }
@@ -599,116 +809,124 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     [self.downloadStateLock lock];
     WorldDownloadCompletionHandler handler = self.downloadCompletionHandlers[downloadTask];
     NSString *destinationPath = self.downloadDestinationPaths[downloadTask];
-    NSString *taskDescription = downloadTask.taskDescription;
+    NSString *stagingDirectory = self.downloadStagingDirectories[downloadTask];
+    NSString *worldName = self.downloadWorldNames[downloadTask];
+    NSString *savesFolder = self.downloadSavesFolders[downloadTask];
     DownloadTaskItem *taskItem = self.downloadTaskItems[downloadTask];
 
     [self.downloadCompletionHandlers removeObjectForKey:downloadTask];
     [self.downloadDestinationPaths removeObjectForKey:downloadTask];
+    [self.downloadStagingDirectories removeObjectForKey:downloadTask];
+    [self.downloadWorldNames removeObjectForKey:downloadTask];
+    [self.downloadSavesFolders removeObjectForKey:downloadTask];
     [self.downloadProgresses removeObjectForKey:downloadTask];
     [self.downloadProgressHandlers removeObjectForKey:downloadTask];
     [self.downloadTaskItems removeObjectForKey:downloadTask];
     [self.downloadProgressSnapshots removeObjectForKey:downloadTask];
     [self.downloadStateLock unlock];
 
-    if (!destinationPath) {
+    if (!destinationPath || !stagingDirectory || !savesFolder) {
         NSError *metadataError = [NSError errorWithDomain:@"WorldServiceError"
                                                       code:6
                                                   userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1098", nil)}];
-        if (taskItem) {
-            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId completedWithError:metadataError];
-        }
-        if (handler) dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, metadataError); });
+        [self cleanupWorldStagingDirectory:stagingDirectory];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (![self isWorldTaskItemCurrent:taskItem generation:generation]) return;
+            DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+            [manager updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
+            [manager setTaskWithId:taskItem.taskId completedWithError:metadataError];
+            if (handler) handler(NO, metadataError);
+        });
         return;
     }
 
     NSFileManager *fm = [NSFileManager defaultManager];
     NSError *moveError = nil;
-    NSString *dir = [destinationPath stringByDeletingLastPathComponent];
-    if (![fm fileExistsAtPath:dir]) {
-        [fm createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
-    }
-    if ([fm fileExistsAtPath:destinationPath]) {
-        [fm removeItemAtPath:destinationPath error:nil];
-    }
     if (![fm moveItemAtURL:location toURL:[NSURL fileURLWithPath:destinationPath] error:&moveError]) {
         NSError *finalMoveError = moveError ?: [NSError errorWithDomain:@"WorldServiceError"
                                                                     code:4
                                                                 userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1096", nil)}];
-        if (taskItem) {
-            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId completedWithError:finalMoveError];
-        }
-        if (handler) dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, finalMoveError); });
+        [self cleanupWorldStagingDirectory:stagingDirectory];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (![self isWorldTaskItemCurrent:taskItem generation:generation]) return;
+            DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+            [manager updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
+            [manager setTaskWithId:taskItem.taskId completedWithError:finalMoveError];
+            if (handler) handler(NO, finalMoveError);
+        });
         return;
     }
 
-    // 解析 taskDescription：worldName 与 savesFolder
-    NSString *worldName = nil;
-    NSString *savesFolder = nil;
-    if (taskDescription.length > 0) {
-        NSArray<NSString *> *parts = [taskDescription componentsSeparatedByString:@"\n"];
-        if (parts.count >= 1) worldName = parts[0];
-        if (parts.count >= 2) savesFolder = parts[1];
-    }
-    if (!savesFolder) {
-        // 无 saves 目录信息，回退：删除临时 zip 并报错
-        [fm removeItemAtPath:destinationPath error:nil];
-        NSError *metadataError = [NSError errorWithDomain:@"WorldServiceError"
-                                                      code:6
-                                                  userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1098", nil)}];
-        if (taskItem) {
-            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
-            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId completedWithError:metadataError];
-        }
-        if (handler) dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, metadataError); });
+    // 下载完成后只允许在 staging 中继续解压。暂停、取消或旧 generation 即使
+    // 解压仍在运行，也只能清理 staging，不能把任何目录提交到 saves。
+    if (![self isWorldTaskItemCurrent:taskItem generation:generation]) {
+        [self cleanupWorldStagingDirectory:stagingDirectory];
         return;
     }
+    taskItem.supportsResume = NO;
+    DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+    [manager updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
+    [manager updateTaskWithId:taskItem.taskId currentStageIndex:1];
+    [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusRunning];
 
-    if (taskItem) {
-        DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
-        [manager updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
-        [manager updateTaskWithId:taskItem.taskId currentStageIndex:1];
-        [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusRunning];
-    }
-
-    // 在后台线程做解压
+    // 后台阶段只写唯一 staging；最终进入 saves 的 rename 在主线程 gate 内完成，
+    // 与 UI 的暂停/取消操作形成确定顺序。
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-        NSError *extractError = nil;
-        BOOL success = [self extractWorldZipAt:destinationPath
-                                    toSavesDir:savesFolder
-                                    worldName:worldName ?: @"imported_world"
-                                        error:&extractError];
-
-        // 解压完成后删除临时 zip
-        [fm removeItemAtPath:destinationPath error:nil];
+        NSError *stageError = nil;
+        PLStagedWorld *stagedWorld = [self stageWorldZipAt:destinationPath
+                                          stagingDirectory:stagingDirectory
+                                                 worldName:worldName ?: @"imported_world"
+                                                     error:&stageError];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
-            DownloadTaskItem *latestTask = taskItem ? [manager taskWithId:taskItem.taskId] : nil;
-            // 下载完成后解压仍在后台运行。若用户在此期间暂停或取消，保持用户
-            // 选择，不再把阶段改写为成功/失败，也不弹出相反的结果提示。
-            if (taskItem &&
-                (latestTask.state != DownloadTaskStateDownloading ||
-                 ![latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation])) {
+            if (![self isWorldTaskItemCurrent:taskItem generation:generation]) {
+                [self cleanupWorldStagingDirectory:stagingDirectory];
                 return;
             }
-            if (success) {
-                if (taskItem) {
-                    [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusCompleted];
-                    [manager setTaskWithId:taskItem.taskId completedWithError:nil];
-                }
-                if (handler) handler(YES, nil);
-            } else {
-                NSError *finalError = extractError ?: [NSError errorWithDomain:@"WorldServiceError"
-                                                                           code:5
-                                                                       userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}];
-                if (taskItem) {
-                    [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusFailed];
-                    [manager setTaskWithId:taskItem.taskId completedWithError:finalError];
-                }
+
+            DownloadTaskManager *currentManager = [DownloadTaskManager sharedManager];
+            if (!stagedWorld) {
+                NSError *finalError = stageError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                         code:5
+                                                                     userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}];
+                [self cleanupWorldStagingDirectory:stagingDirectory];
+                [currentManager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusFailed];
+                [currentManager setTaskWithId:taskItem.taskId completedWithError:finalError];
                 if (handler) handler(NO, finalError);
+                return;
             }
+
+            NSError *commitError = nil;
+            NSString *installedWorldPath = [self commitStagedWorld:stagedWorld
+                                                        toSavesDir:savesFolder
+                                                             error:&commitError];
+            [self cleanupWorldStagingDirectory:stagingDirectory];
+            if (!installedWorldPath) {
+                NSError *finalError = commitError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                          code:5
+                                                                      userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}];
+                if (![self isWorldTaskItemCurrent:taskItem generation:generation]) return;
+                [currentManager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusFailed];
+                [currentManager setTaskWithId:taskItem.taskId completedWithError:finalError];
+                if (handler) handler(NO, finalError);
+                return;
+            }
+
+            // 防御后台状态变更：若 commit 后任务已不再属于本 generation，回滚
+            // 本次唯一目标。它从未覆盖旧世界，因此可安全删除。
+            if (![self isWorldTaskItemCurrent:taskItem generation:generation]) {
+                [fm removeItemAtPath:installedWorldPath error:nil];
+                return;
+            }
+            [currentManager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusCompleted];
+            [currentManager setTaskWithId:taskItem.taskId completedWithError:nil];
+            DownloadTaskItem *completedTask = [currentManager taskWithId:taskItem.taskId];
+            if (completedTask.state != DownloadTaskStateCompleted ||
+                ![completedTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation]) {
+                [fm removeItemAtPath:installedWorldPath error:nil];
+                return;
+            }
+            if (handler) handler(YES, nil);
         });
     });
 }
@@ -719,13 +937,18 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         [self.downloadStateLock lock];
         WorldDownloadCompletionHandler handler = self.downloadCompletionHandlers[task];
         DownloadTaskItem *taskItem = self.downloadTaskItems[task];
+        NSString *stagingDirectory = self.downloadStagingDirectories[task];
         [self.downloadTaskItems removeObjectForKey:task];
         [self.downloadProgressSnapshots removeObjectForKey:task];
         [self.downloadCompletionHandlers removeObjectForKey:task];
         [self.downloadDestinationPaths removeObjectForKey:task];
+        [self.downloadStagingDirectories removeObjectForKey:task];
+        [self.downloadWorldNames removeObjectForKey:task];
+        [self.downloadSavesFolders removeObjectForKey:task];
         [self.downloadProgresses removeObjectForKey:task];
         [self.downloadProgressHandlers removeObjectForKey:task];
         [self.downloadStateLock unlock];
+        [self cleanupWorldStagingDirectory:stagingDirectory];
 
         dispatch_async(dispatch_get_main_queue(), ^{
             DownloadTaskManager *manager = [DownloadTaskManager sharedManager];

--- a/Natives/WorldService.m
+++ b/Natives/WorldService.m
@@ -20,6 +20,8 @@
 #import "PLTaskStages.h"
 #import "LauncherPreferences.h"
 
+static NSString * const PLWorldDownloadGenerationKey = @"worldDownloadGeneration";
+
 @interface WorldService () <NSURLSessionDownloadDelegate>
 @property (nonatomic, strong) NSURLSession *downloadSession;
 // 内部统一存储带 success/error 的 completion handler
@@ -30,6 +32,7 @@
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSProgress *> *downloadProgresses;
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, DownloadTaskItem *> *downloadTaskItems;
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, NSMutableDictionary *> *downloadProgressSnapshots;
+@property (nonatomic, strong) NSLock *downloadStateLock;
 // 导入任务专用字典（不通过 NSURLSession 下载，但同样需要进度上报）
 @property (nonatomic, strong) NSMutableDictionary<NSString *, WorldDownloadCompletionHandler> *importCompletionHandlers;
 @end
@@ -61,6 +64,7 @@
         _downloadProgresses = [NSMutableDictionary dictionary];
         _downloadTaskItems = [NSMutableDictionary dictionary];
         _downloadProgressSnapshots = [NSMutableDictionary dictionary];
+        _downloadStateLock = [[NSLock alloc] init];
         _importCompletionHandlers = [NSMutableDictionary dictionary];
     }
     return self;
@@ -70,84 +74,24 @@
 
 // 解析 profile 的 gameDir，返回 gameDir 或 nil
 - (nullable NSString *)gameDirForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                return gameDir;
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        return [NSString stringWithUTF8String:gameDirC];
-    }
-    return nil;
+    return [PLProfiles resolvedGameDirectoryForProfileName:profileName];
 }
 
 #pragma mark - Saves folder detection & scan
 
 // 查找指定 profile 的 saves 目录（已存在时返回路径，否则返回 nil）
 - (nullable NSString *)existingWorldsFolderForProfile:(NSString *)profileName {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                NSString *savesPath = [gameDir stringByAppendingPathComponent:@"saves"];
-                BOOL isDir = NO;
-                if ([fm fileExistsAtPath:savesPath isDirectory:&isDir] && isDir) {
-                    return savesPath;
-                }
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    // 回退：读取 POJAV_GAME_DIR 环境变量
-    const char *gameDirC = getenv("POJAV_GAME_DIR");
-    if (gameDirC) {
-        NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-        NSString *savesPath = [gameDir stringByAppendingPathComponent:@"saves"];
-        BOOL isDir = NO;
-        if ([fm fileExistsAtPath:savesPath isDirectory:&isDir] && isDir) {
-            return savesPath;
-        }
-    }
+    NSString *savesPath = [[self gameDirForProfile:profileName] stringByAppendingPathComponent:@"saves"];
+    BOOL isDir = NO;
+    if ([fm fileExistsAtPath:savesPath isDirectory:&isDir] && isDir) return savesPath;
     return nil;
 }
 
 /// 获取当前 profile 的 saves 目录，不存在时自动创建
 - (nullable NSString *)ensureWorldsFolderForProfile:(NSString *)profileName error:(NSError **)error {
-    NSString *profile = profileName.length ? profileName : @"default";
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *savesPath = nil;
-
-    @try {
-        NSDictionary *profiles = PLProfiles.current.profiles;
-        NSDictionary *prof = profiles[profile];
-        if ([prof isKindOfClass:[NSDictionary class]]) {
-            NSString *gameDir = prof[@"gameDir"];
-            if ([gameDir isKindOfClass:[NSString class]] && gameDir.length > 0) {
-                savesPath = [gameDir stringByAppendingPathComponent:@"saves"];
-            }
-        }
-    } @catch (NSException *ex) { }
-
-    if (!savesPath) {
-        const char *gameDirC = getenv("POJAV_GAME_DIR");
-        if (gameDirC) {
-            NSString *gameDir = [NSString stringWithUTF8String:gameDirC];
-            savesPath = [gameDir stringByAppendingPathComponent:@"saves"];
-        }
-    }
+    NSString *savesPath = [[self gameDirForProfile:profileName] stringByAppendingPathComponent:@"saves"];
 
     if (!savesPath) {
         if (error) {
@@ -268,6 +212,20 @@
 // - 若 zip 内有顶层目录，直接解压到 saves/
 // - 若 zip 内无顶层目录（散装），先用世界名创建子目录，再解压到该子目录
 // - worldName 用于无顶层目录时命名新世界目录
+- (nullable NSString *)worldDirectoryContainingLevelDatUnderPath:(NSString *)rootPath {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *directLevelDat = [rootPath stringByAppendingPathComponent:@"level.dat"];
+    if ([fm fileExistsAtPath:directLevelDat]) return rootPath;
+
+    NSDirectoryEnumerator<NSString *> *enumerator = [fm enumeratorAtPath:rootPath];
+    for (NSString *relativePath in enumerator) {
+        if ([[relativePath lastPathComponent] isEqualToString:@"level.dat"]) {
+            return [[rootPath stringByAppendingPathComponent:relativePath] stringByDeletingLastPathComponent];
+        }
+    }
+    return nil;
+}
+
 - (BOOL)extractWorldZipAt:(NSString *)zipPath
                 toSavesDir:(NSString *)savesDir
                 worldName:(NSString *)worldName
@@ -277,11 +235,13 @@
     NSString *topLevelDir = [self detectTopLevelDirectoryInZip:zipPath];
     NSString *extractTargetDir = nil;
     NSString *finalWorldDir = nil;
+    BOOL finalWorldDirExistedBefore = NO;
 
     if (topLevelDir) {
         // zip 内有顶层目录，直接解压到 saves/
         extractTargetDir = savesDir;
         finalWorldDir = [savesDir stringByAppendingPathComponent:topLevelDir];
+        finalWorldDirExistedBefore = [fm fileExistsAtPath:finalWorldDir];
     } else {
         // zip 内无顶层目录，需要创建子目录后再解压
         NSString *baseName = worldName.length > 0 ? worldName : [zipPath lastPathComponent];
@@ -311,6 +271,7 @@
     NSError *archiveError = nil;
     UZKArchive *archive = [[UZKArchive alloc] initWithPath:zipPath error:&archiveError];
     if (!archive || archiveError) {
+        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
         if (error) *error = archiveError;
         return NO;
     }
@@ -319,21 +280,39 @@
     BOOL success = [archive extractFilesTo:extractTargetDir overwrite:YES error:&extractError];
     if (!success || extractError) {
         if (error) *error = extractError;
-        // 解压失败时若我们创建了子目录，清理掉空目录
-        if (!topLevelDir && [fm fileExistsAtPath:extractTargetDir]) {
-            NSArray<NSString *> *leftover = [fm contentsOfDirectoryAtPath:extractTargetDir error:nil];
-            if (leftover.count == 0) {
-                [fm removeItemAtPath:extractTargetDir error:nil];
-            }
+        // 仅清理本次新建的世界目录，保留下载前已经存在的用户数据。
+        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
+        return NO;
+    }
+
+    // Minecraft 只识别 saves/ 的直接子目录。若压缩包多套了一层目录，找到真正
+    // 包含 level.dat 的目录并提升到 saves/，否则管理页和游戏都会把它当作不存在。
+    NSString *actualWorldDir = [self worldDirectoryContainingLevelDatUnderPath:finalWorldDir];
+    if (!actualWorldDir) {
+        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
+        if (error) {
+            *error = [NSError errorWithDomain:@"WorldServiceError"
+                                         code:7
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The downloaded archive does not contain a valid Minecraft world (level.dat is missing)."}];
         }
         return NO;
     }
 
-    // 校验解压结果：必须存在 level.dat（可能在 finalWorldDir 直接下，也可能在更深一层）
-    NSString *levelDatCheck = [finalWorldDir stringByAppendingPathComponent:@"level.dat"];
-    if (![fm fileExistsAtPath:levelDatCheck]) {
-        // 有些 zip 即使有顶层目录，level.dat 可能还在更深层。这里只做日志，不阻断
-        NSLog(@"[WorldService] warning: level.dat not found at %@ after extraction", finalWorldDir);
+    if (![actualWorldDir isEqualToString:finalWorldDir]) {
+        NSString *baseName = actualWorldDir.lastPathComponent.length > 0 ? actualWorldDir.lastPathComponent : worldName;
+        NSString *promotedWorldDir = [savesDir stringByAppendingPathComponent:baseName];
+        NSInteger suffix = 1;
+        while ([fm fileExistsAtPath:promotedWorldDir]) {
+            promotedWorldDir = [savesDir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%ld", baseName, (long)suffix++]];
+        }
+
+        NSError *moveError = nil;
+        if (![fm moveItemAtPath:actualWorldDir toPath:promotedWorldDir error:&moveError]) {
+            if (error) *error = moveError;
+            return NO;
+        }
+        if (!finalWorldDirExistedBefore) [fm removeItemAtPath:finalWorldDir error:nil];
+        finalWorldDir = promotedWorldDir;
     }
 
     NSLog(@"[WorldService] world extracted to: %@", finalWorldDir);
@@ -379,16 +358,13 @@
 
     // 创建下载任务（默认会话配置，无后台限速）
     NSURLSessionDownloadTask *task = [self.downloadSession downloadTaskWithURL:url];
-    self.downloadCompletionHandlers[task] = completion;
-    self.downloadDestinationPaths[task] = destinationPath;
     // 用 taskDescription 暂存世界名和 saves 目录（用于解压阶段）
     // 格式："worldName\nsavesFolder"
     task.taskDescription = [NSString stringWithFormat:@"%@\n%@", worldNameForExtract, savesFolder];
+    NSProgress *progressObj = nil;
     if (progress) {
-        NSProgress *progressObj = [NSProgress progressWithTotalUnitCount:-1];
+        progressObj = [NSProgress progressWithTotalUnitCount:-1];
         progressObj.kind = NSProgressKindFile;
-        self.downloadProgresses[task] = progressObj;
-        self.downloadProgressHandlers[task] = progress;
     }
 
     // 注册到统一下载任务管理器（悬浮球已移除，始终注册以便下载任务列表跟踪）
@@ -404,12 +380,28 @@
                       supportsResume:YES
                              iconURL:item.iconURL];
     taskItem.downloadURL = item.selectedVersionDownloadURL;
+    NSString *taskProfileName = [PLProfiles effectiveProfileNameForPreferredName:profileName];
+    if (taskProfileName.length > 0) taskItem.userInfo[@"profileName"] = taskProfileName;
+    taskItem.userInfo[@"destinationPath"] = destinationPath;
+    taskItem.userInfo[PLWorldDownloadGenerationKey] = @(task.taskIdentifier);
+    // 世界暂停恢复需要用新的 NSURLSessionTask 从头重建，不应消耗网络失败重试预算。
+    taskItem.maxRetryCount = 0;
+    taskItem.autoPresentDetail = YES;
+    [self.downloadStateLock lock];
+    if (completion) self.downloadCompletionHandlers[task] = completion;
+    self.downloadDestinationPaths[task] = destinationPath;
+    if (progressObj) self.downloadProgresses[task] = progressObj;
+    if (progress) self.downloadProgressHandlers[task] = progress;
     self.downloadTaskItems[task] = taskItem;
+    [self.downloadStateLock unlock];
+    [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId stages:PLTaskStagesWorld()];
     [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId state:DownloadTaskStateDownloading];
+    [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusRunning];
 
     // 设置 retryHandler：FCL 风格重新下载
     __weak typeof(self) weakSelf = self;
     NSString *capturedDestPath = destinationPath;
+    NSString *capturedTaskDescription = task.taskDescription;
     WorldDownloadCompletionHandler capturedCompletion = completion;
     void (^capturedProgress)(NSProgress *) = progress;
     taskItem.retryHandler = ^id(DownloadTaskItem *taskItemRef) {
@@ -418,13 +410,24 @@
         NSURL *retryURL = [NSURL URLWithString:taskItemRef.downloadURL] ?: url;
         if (!retryURL) return nil;
         NSURLSessionDownloadTask *newTask = [strongSelf.downloadSession downloadTaskWithURL:retryURL];
-        strongSelf.downloadCompletionHandlers[newTask] = capturedCompletion;
+        newTask.taskDescription = capturedTaskDescription;
+        taskItemRef.userInfo[PLWorldDownloadGenerationKey] = @(newTask.taskIdentifier);
+        // manager 随后依据 rawTask 获取并发槽；必须在切换 Downloading 前写入。
+        taskItemRef.rawTask = newTask;
+        [strongSelf.downloadStateLock lock];
+        if (capturedCompletion) strongSelf.downloadCompletionHandlers[newTask] = capturedCompletion;
         strongSelf.downloadDestinationPaths[newTask] = capturedDestPath;
         if (capturedProgress) {
+            NSProgress *progressObj = [NSProgress progressWithTotalUnitCount:-1];
+            progressObj.kind = NSProgressKindFile;
+            strongSelf.downloadProgresses[newTask] = progressObj;
             strongSelf.downloadProgressHandlers[newTask] = capturedProgress;
         }
         strongSelf.downloadTaskItems[newTask] = taskItemRef;
+        [strongSelf.downloadStateLock unlock];
+        [[DownloadTaskManager sharedManager] setTaskWithId:taskItemRef.taskId stages:PLTaskStagesWorld()];
         [[DownloadTaskManager sharedManager] setTaskWithId:taskItemRef.taskId state:DownloadTaskStateDownloading];
+        [[DownloadTaskManager sharedManager] updateTaskWithId:taskItemRef.taskId stageAtIndex:0 status:PLTaskStageStatusRunning];
         [newTask resume];
         return newTask;
     };
@@ -535,6 +538,7 @@
       didWriteData:(int64_t)bytesWritten
  totalBytesWritten:(int64_t)totalBytesWritten
 totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+    [self.downloadStateLock lock];
     NSProgress *progressObj = self.downloadProgresses[downloadTask];
     WorldDownloadProgressHandler progressHandler = self.downloadProgressHandlers[downloadTask];
     DownloadTaskItem *taskItem = self.downloadTaskItems[downloadTask];
@@ -560,7 +564,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         }
         snapshot[@"lastTime"] = @(now);
         snapshot[@"lastBytes"] = @(totalBytesWritten);
-
+        [self.downloadStateLock unlock];
         [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId
                                                      progress:fraction
                                                    totalBytes:totalBytesExpectedToWrite
@@ -568,6 +572,12 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId
                                                           speed:speed
                                         estimatedTimeRemaining:eta];
+        [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId
+                                                  stageAtIndex:0
+                                                      progress:fraction
+                                                       message:nil];
+    } else {
+        [self.downloadStateLock unlock];
     }
 
     if (!progressObj || !progressHandler) return;
@@ -585,6 +595,8 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location {
+    NSNumber *generation = @(downloadTask.taskIdentifier);
+    [self.downloadStateLock lock];
     WorldDownloadCompletionHandler handler = self.downloadCompletionHandlers[downloadTask];
     NSString *destinationPath = self.downloadDestinationPaths[downloadTask];
     NSString *taskDescription = downloadTask.taskDescription;
@@ -596,8 +608,17 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     [self.downloadProgressHandlers removeObjectForKey:downloadTask];
     [self.downloadTaskItems removeObjectForKey:downloadTask];
     [self.downloadProgressSnapshots removeObjectForKey:downloadTask];
+    [self.downloadStateLock unlock];
 
-    if (!handler || !destinationPath) {
+    if (!destinationPath) {
+        NSError *metadataError = [NSError errorWithDomain:@"WorldServiceError"
+                                                      code:6
+                                                  userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1098", nil)}];
+        if (taskItem) {
+            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
+            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId completedWithError:metadataError];
+        }
+        if (handler) dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, metadataError); });
         return;
     }
 
@@ -611,16 +632,15 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         [fm removeItemAtPath:destinationPath error:nil];
     }
     if (![fm moveItemAtURL:location toURL:[NSURL fileURLWithPath:destinationPath] error:&moveError]) {
+        NSError *finalMoveError = moveError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                    code:4
+                                                                userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1096", nil)}];
         if (taskItem) {
-            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId error:moveError];
-            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId state:DownloadTaskStateFailed];
+            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
+            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId completedWithError:finalMoveError];
         }
-        dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, moveError); });
+        if (handler) dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, finalMoveError); });
         return;
-    }
-
-    if (taskItem) {
-        [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId state:DownloadTaskStateCompleted];
     }
 
     // 解析 taskDescription：worldName 与 savesFolder
@@ -634,12 +654,22 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     if (!savesFolder) {
         // 无 saves 目录信息，回退：删除临时 zip 并报错
         [fm removeItemAtPath:destinationPath error:nil];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            handler(NO, [NSError errorWithDomain:@"WorldServiceError"
-                                            code:6
-                                        userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1098", nil)}]);
-        });
+        NSError *metadataError = [NSError errorWithDomain:@"WorldServiceError"
+                                                      code:6
+                                                  userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1098", nil)}];
+        if (taskItem) {
+            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
+            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId completedWithError:metadataError];
+        }
+        if (handler) dispatch_async(dispatch_get_main_queue(), ^{ handler(NO, metadataError); });
         return;
+    }
+
+    if (taskItem) {
+        DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+        [manager updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusCompleted];
+        [manager updateTaskWithId:taskItem.taskId currentStageIndex:1];
+        [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusRunning];
     }
 
     // 在后台线程做解压
@@ -654,12 +684,30 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         [fm removeItemAtPath:destinationPath error:nil];
 
         dispatch_async(dispatch_get_main_queue(), ^{
+            DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+            DownloadTaskItem *latestTask = taskItem ? [manager taskWithId:taskItem.taskId] : nil;
+            // 下载完成后解压仍在后台运行。若用户在此期间暂停或取消，保持用户
+            // 选择，不再把阶段改写为成功/失败，也不弹出相反的结果提示。
+            if (taskItem &&
+                (latestTask.state != DownloadTaskStateDownloading ||
+                 ![latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation])) {
+                return;
+            }
             if (success) {
-                handler(YES, nil);
+                if (taskItem) {
+                    [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusCompleted];
+                    [manager setTaskWithId:taskItem.taskId completedWithError:nil];
+                }
+                if (handler) handler(YES, nil);
             } else {
-                handler(NO, extractError ?: [NSError errorWithDomain:@"WorldServiceError"
-                                                                code:5
-                                                            userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}]);
+                NSError *finalError = extractError ?: [NSError errorWithDomain:@"WorldServiceError"
+                                                                           code:5
+                                                                       userInfo:@{NSLocalizedDescriptionKey: localize(@"i18n_str_1097", nil)}];
+                if (taskItem) {
+                    [manager updateTaskWithId:taskItem.taskId stageAtIndex:1 status:PLTaskStageStatusFailed];
+                    [manager setTaskWithId:taskItem.taskId completedWithError:finalError];
+                }
+                if (handler) handler(NO, finalError);
             }
         });
     });
@@ -667,21 +715,49 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
     if (error) {
+        NSNumber *generation = @(task.taskIdentifier);
+        [self.downloadStateLock lock];
         WorldDownloadCompletionHandler handler = self.downloadCompletionHandlers[task];
         DownloadTaskItem *taskItem = self.downloadTaskItems[task];
-        if (taskItem) {
-            [[DownloadTaskManager sharedManager] updateTaskWithId:taskItem.taskId error:error];
-            [[DownloadTaskManager sharedManager] setTaskWithId:taskItem.taskId state:DownloadTaskStateFailed];
-            [self.downloadTaskItems removeObjectForKey:task];
-            [self.downloadProgressSnapshots removeObjectForKey:task];
-        }
-        if (handler) {
-            handler(NO, error);
-            [self.downloadCompletionHandlers removeObjectForKey:task];
-            [self.downloadDestinationPaths removeObjectForKey:task];
-            [self.downloadProgresses removeObjectForKey:task];
-            [self.downloadProgressHandlers removeObjectForKey:task];
-        }
+        [self.downloadTaskItems removeObjectForKey:task];
+        [self.downloadProgressSnapshots removeObjectForKey:task];
+        [self.downloadCompletionHandlers removeObjectForKey:task];
+        [self.downloadDestinationPaths removeObjectForKey:task];
+        [self.downloadProgresses removeObjectForKey:task];
+        [self.downloadProgressHandlers removeObjectForKey:task];
+        [self.downloadStateLock unlock];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            DownloadTaskManager *manager = [DownloadTaskManager sharedManager];
+            DownloadTaskItem *latestTask = taskItem ? [manager taskWithId:taskItem.taskId] : nil;
+            BOOL isCancellation = [error.domain isEqualToString:NSURLErrorDomain] &&
+                                  error.code == NSURLErrorCancelled;
+            // 该回调若属于已被 retry 替换的旧 NSURLSessionTask，只清理旧映射，
+            // 不得影响新一代任务。
+            if (taskItem &&
+                (!latestTask ||
+                 ![latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation])) {
+                return;
+            }
+            // cancelByProducingResumeData: 也以 NSURLErrorCancelled 收尾。暂停时等待
+            // retryHandler 的最终结果；显式取消由任务列表状态表达，均不误报失败。
+            if (isCancellation) {
+                // 用户在 cancelByProducingResumeData: 尚未收尾时快速点了继续，
+                // manager 会暂时回到 Downloading。旧任务已经无法恢复，转为一次
+                // 原子重试，避免卡在没有活动 rawTask 的“下载中”。
+                if (latestTask.state == DownloadTaskStateDownloading) {
+                    [manager setTaskWithId:taskItem.taskId state:DownloadTaskStatePaused];
+                    [manager retryTaskWithId:taskItem.taskId];
+                }
+                return;
+            }
+            if (taskItem && latestTask.state != DownloadTaskStateDownloading) return;
+            if (taskItem) {
+                [manager updateTaskWithId:taskItem.taskId stageAtIndex:0 status:PLTaskStageStatusFailed];
+                [manager setTaskWithId:taskItem.taskId completedWithError:error];
+            }
+            if (handler) handler(NO, error);
+        });
     }
 }
 

--- a/Natives/WorldsManagerViewController.m
+++ b/Natives/WorldsManagerViewController.m
@@ -12,6 +12,8 @@
 #import "WorldItem.h"
 #import "ResourceCardTableViewCell.h"
 #import "DownloadViewController.h"
+#import "DownloadTaskManager.h"
+#import "PLProfiles.h"
 #import "utils.h"
 
 #pragma mark - 世界卡片 Cell（继承 Air-Design 卡片基类，本文件内轻量子类）
@@ -77,6 +79,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.profileName = [PLProfiles effectiveProfileNameForPreferredName:self.profileName];
     // 在线下载入口已移至下载界面：固定本地模式（currentMode 等属性保留仅为兼容 .h 既有声明）
     self.currentMode = WorldsManagerModeLocal;
     self.localItems = [NSMutableArray array];
@@ -106,6 +109,14 @@
     self.navigationItem.leftBarButtonItem = closeButton;
     self.navigationItem.rightBarButtonItems = @[self.importButton, self.refreshButton];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDownloadTaskCompleted:)
+                                                 name:DownloadTaskManagerTaskCompletedNotification
+                                               object:nil];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [self refreshLocalList];
 }
 
@@ -275,6 +286,8 @@
 - (void)openDownloadPage {
     // 在线下载入口已收敛到统一下载界面（未区分资源类型 Tab，进入默认页）
     DownloadViewController *downloadVC = [[DownloadViewController alloc] init];
+    downloadVC.initialTabIndex = 6;
+    downloadVC.targetProfileName = self.profileName;
     if (self.navigationController) {
         [self.navigationController pushViewController:downloadVC animated:YES];
     } else {
@@ -283,6 +296,14 @@
         nav.modalPresentationStyle = UIModalPresentationFullScreen;
         [self presentViewController:nav animated:YES completion:nil];
     }
+}
+
+- (void)handleDownloadTaskCompleted:(NSNotification *)notification {
+    DownloadTaskItem *task = notification.userInfo[DownloadTaskManagerTaskKey];
+    if (task.state != DownloadTaskStateCompleted ||
+        ![task.resourceType isEqualToString:DownloadTaskResourceTypeWorld] ||
+        ![task.userInfo[@"profileName"] isEqualToString:self.profileName]) return;
+    [self refreshLocalList];
 }
 
 #pragma mark - UITableView DataSource & Delegate

--- a/Natives/egl_bridge.m
+++ b/Natives/egl_bridge.m
@@ -1,4 +1,5 @@
 #import "SurfaceViewController.h"
+#import "LauncherPreferences.h"
 
 #include "jni.h"
 #include <assert.h>
@@ -107,12 +108,10 @@ int pojavInit(BOOL useStackQueue) {
 }
 
 int pojavInitOpenGL() {
-    NSString *renderer = NSProcessInfo.processInfo.environment[@"AMETHYST_RENDERER"];
-    BOOL isAuto = [renderer isEqualToString:@"auto"];
-    if (isAuto || [renderer isEqualToString:@ RENDERER_NAME_GL4ES]) {
-        // At this point, if renderer is still auto (unspecified major version), pick gl4es
-        renderer = @ RENDERER_NAME_GL4ES;
-        setenv("AMETHYST_RENDERER", renderer.UTF8String, 1);
+    // 复用唯一 resolver；即使旁路调用没有经过 JavaLauncher，也与正常启动保持同一语义。
+    NSString *renderer = PLResolveRendererKey(NSProcessInfo.processInfo.environment[@"AMETHYST_RENDERER"]);
+    setenv("AMETHYST_RENDERER", renderer.UTF8String, 1);
+    if ([renderer isEqualToString:@ RENDERER_NAME_GL4ES]) {
         set_gl_bridge_tbl();
     } else if ([renderer isEqualToString:@ RENDERER_NAME_MOBILEGLUES]) {
         renderer = @ RENDERER_NAME_MOBILEGLUES;
@@ -187,19 +186,6 @@ int pojavInitOpenGL() {
 void pojavSetWindowHint(int hint, int value) {
     if (hint == GLFW_CLIENT_API) {
         clientAPI = value;
-    } else if (strcmp(getenv("AMETHYST_RENDERER"), "auto")==0 && hint == GLFW_CONTEXT_VERSION_MAJOR) {
-        switch (value) {
-            case 1:
-            case 2:
-                setenv("AMETHYST_RENDERER", RENDERER_NAME_GL4ES, 1);
-                JNI_LWJGL_changeRenderer(RENDERER_NAME_GL4ES);
-                break;
-            // case 4: use Zink?
-            default:
-                setenv("AMETHYST_RENDERER", RENDERER_NAME_MOBILEGLUES, 1);
-                JNI_LWJGL_changeRenderer(RENDERER_NAME_MOBILEGLUES);
-                break;
-        }
     }
 }
 
@@ -313,4 +299,3 @@ void pojavSwapInterval(int interval) {
 
     br_swap_interval(interval);
 }
-

--- a/Natives/resources/ar.lproj/Localizable.strings
+++ b/Natives/resources/ar.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "preference.title.renderer.release.angle" = "ANGLE";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "تلقائياً: gl4es أو ANGLE";
+"preference.title.renderer.debug.auto" = "تلقائياً: ANGLE";
 "preference.title.renderer.debug.gl4es" = "holy gl4es - exports OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - الصادرات OpenGL 3.2 (موجز أساسي محدود)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exports OpenGL 4.1";

--- a/Natives/resources/cs.lproj/Localizable.strings
+++ b/Natives/resources/cs.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "preference.title.renderer.release.angle" = "ANGLE";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "Automaticky: gl4es či ANGLE";
+"preference.title.renderer.debug.auto" = "Automaticky: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - exportuje OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - exportuje OpenGL 3.2 (Jádrový Profil, omezen)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exportuje OpenGL 4.1";

--- a/Natives/resources/de.lproj/Localizable.strings
+++ b/Natives/resources/de.lproj/Localizable.strings
@@ -168,7 +168,7 @@ der Minecraft-Version zu wählen. Verringerte Auflösung reduziert die Arbeitsla
 "preference.title.renderer.release.angle" = "Angle";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "Auto: gl4es or ANGLE";
+"preference.title.renderer.debug.auto" = "Auto: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - gibt OpenGL 2.1 aus";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - gibt OpenGL 3.2 (Kernprofil, begrenzt) aus";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - gibt OpenGL 4.1 aus";

--- a/Natives/resources/en.lproj/Localizable.strings
+++ b/Natives/resources/en.lproj/Localizable.strings
@@ -233,7 +233,7 @@
 "preference.title.renderer.release.mg" = "MobileGlues";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "Auto: gl4es or ANGLE";
+"preference.title.renderer.debug.auto" = "Auto: ANGLE";
 "preference.title.renderer.debug.gl4es" = "holy gl4es - exports OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - exports OpenGL 3.2 (Core Profile, limited)";
 "preference.title.renderer.debug.mg" = "MobileGlues (1.17+) - exports OpenGL 4.0, EXPERIMENTAL";

--- a/Natives/resources/es.lproj/Localizable.strings
+++ b/Natives/resources/es.lproj/Localizable.strings
@@ -129,7 +129,7 @@
 
 "preference.title.renderer" = "Renderizador";
 
-"preference.title.renderer.debug.auto" = "Automático: gl4es o ANGLE";
+"preference.title.renderer.debug.auto" = "Automático: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - exporta a OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - exporta OpenGL 3.1 (perfil Core, limitado)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exporta a OpenGL 4.1";

--- a/Natives/resources/et.lproj/Localizable.strings
+++ b/Natives/resources/et.lproj/Localizable.strings
@@ -52,7 +52,7 @@
 
 "preference.title.renderer" = "Renderdaja";
 
-"preference.title.renderer.debug.auto" = "Autom.: gl4es või ANGLE";
+"preference.title.renderer.debug.auto" = "Autom.: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - väljastab OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - väljastab OpenGL 3.2 (Core Profile, piiratud)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - väljastab OpenGL 4.1";

--- a/Natives/resources/fa.lproj/Localizable.strings
+++ b/Natives/resources/fa.lproj/Localizable.strings
@@ -137,7 +137,7 @@
 
 "preference.title.renderer" = "رندر کننده";
 
-"preference.title.renderer.debug.auto" = "خودکار: gl4es یا ANGLE";
+"preference.title.renderer.debug.auto" = "خودکار: ANGLE";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - OpenGL 3.2 را صادر می کند (نمایه هسته، محدود)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - OpenGL 4.1 را صادر می کند";
 

--- a/Natives/resources/fil.lproj/Localizable.strings
+++ b/Natives/resources/fil.lproj/Localizable.strings
@@ -137,7 +137,7 @@
 
 "preference.title.renderer" = "Renderer";
 
-"preference.title.renderer.debug.auto" = "Auto: gl4es or ANGLE";
+"preference.title.renderer.debug.auto" = "Auto: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - ini-export ang OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "tinygl4angle (1.17+) - ini-export ang OpenGL 3.2 (Core Profile, limitado)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - ini-export ang OpenGL 4.1";

--- a/Natives/resources/fr.lproj/Localizable.strings
+++ b/Natives/resources/fr.lproj/Localizable.strings
@@ -139,7 +139,7 @@
 
 "preference.title.renderer" = "Moteur de rendu";
 
-"preference.title.renderer.debug.auto" = "Auto: gl4es ou ANGLE";
+"preference.title.renderer.debug.auto" = "Auto: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - exporte OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - exporte OpenGL 3.2 (Profil de base, Limité)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exporte OpenGL 4.1";

--- a/Natives/resources/id.lproj/Localizable.strings
+++ b/Natives/resources/id.lproj/Localizable.strings
@@ -151,7 +151,7 @@
 
 "preference.title.renderer" = "Renderer";
 
-"preference.title.renderer.debug.auto" = "Otomatis: gl4es atau ANGLE";
+"preference.title.renderer.debug.auto" = "Otomatis: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - mengekspor OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - mengekspor OpenGL 3.2 (Profil Core, terbatas)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - mengekspor OpenGL 4.1";

--- a/Natives/resources/ja.lproj/Localizable.strings
+++ b/Natives/resources/ja.lproj/Localizable.strings
@@ -137,7 +137,7 @@
 
 "preference.title.renderer" = "レンダラー";
 
-"preference.title.renderer.debug.auto" = "自動: gl4es または angle";
+"preference.title.renderer.debug.auto" = "自動: ANGLE";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - エクスポートOpenGL 3.2 (Core Profile, limited)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exports OpenGL 4.1";
 

--- a/Natives/resources/pt-BR.lproj/Localizable.strings
+++ b/Natives/resources/pt-BR.lproj/Localizable.strings
@@ -127,7 +127,7 @@
 
 "preference.title.renderer" = "Renderizador";
 
-"preference.title.renderer.debug.auto" = "Auto: gl4es ou ANGLE";
+"preference.title.renderer.debug.auto" = "Auto: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - exports OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - exporta OpenGL 3.2 (Perfil de navegação, limitado)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - exports OpenGL 4.1";

--- a/Natives/resources/ru.lproj/Localizable.strings
+++ b/Natives/resources/ru.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "preference.title.renderer.release.angle" = "ANGLE";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "Авто: gl4es или ANGLE";
+"preference.title.renderer.debug.auto" = "Авто: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 — обеспечивает OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) — обеспечивает OpenGL 3.2 (ограниченно, Core Profile)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) — обеспечивает OpenGL 4.1";

--- a/Natives/resources/tr.lproj/Localizable.strings
+++ b/Natives/resources/tr.lproj/Localizable.strings
@@ -139,7 +139,7 @@ Bu seçenek varsayılan JitStreamer sunucusunu kullanıyorsanız olduğu gibi b�
 
 "preference.title.renderer" = "İşleyici";
 
-"preference.title.renderer.debug.auto" = "Oto: gl4es ya da ANGLE";
+"preference.title.renderer.debug.auto" = "Oto: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - OpenGL 2.1 çıkarır";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - OpenGL 3.2 dışa aktarır (Çekirdek profili, kısıtlı)";
 "preference.title.renderer.debug.zink" = "Zonk (Mesa 25.0.7) - OpenGL 4.1 çıkarır";

--- a/Natives/resources/uk.lproj/Localizable.strings
+++ b/Natives/resources/uk.lproj/Localizable.strings
@@ -165,7 +165,7 @@
 "preference.title.renderer.release.angle" = "ANGLE";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "Авто: gl4 або ANGLE";
+"preference.title.renderer.debug.auto" = "Авто: ANGLE";
 "preference.title.renderer.debug.gl4es" = "Gl4es 1.1.4 - експортує OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE (1.17+) - експортує OpenGL 3.2 (Базовий профіль, обмежений)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - експортує OpenGL 4.1";

--- a/Natives/resources/vi.lproj/Localizable.strings
+++ b/Natives/resources/vi.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "preference.title.renderer.release.angle" = "GÓC";
 "preference.title.renderer.release.zink" = "Kẽm";
 
-"preference.title.renderer.debug.auto" = "Tự động: gl4es hoặc ANGLE";
+"preference.title.renderer.debug.auto" = "Tự động: ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 - xuất ra OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "tinygl4angle (1.17+) - xuất ra OpenGL 3.2 (Core Profile, bị giới hạn)";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) - xuất ra OpenGL 4.1";

--- a/Natives/resources/zh-Hans.lproj/Localizable.strings
+++ b/Natives/resources/zh-Hans.lproj/Localizable.strings
@@ -236,7 +236,7 @@
 "preference.title.renderer.release.angle" = "ANGLE";
 "preference.title.renderer.release.zink" = "Zink";
 
-"preference.title.renderer.debug.auto" = "自动：gl4es或MobileGlues";
+"preference.title.renderer.debug.auto" = "自动：ANGLE";
 "preference.title.renderer.debug.gl4es" = "holy gl4es 1.1.4 - OpenGL版本2.1";
 "preference.title.renderer.debug.angle" = "ANGLE（仅支持1.17+）- OpenGL 版本 3.2";
 "preference.title.renderer.debug.mg" = "MobileGlues（1.17+）- OpenGL 版本 4.0，实验性";

--- a/Natives/resources/zh-Hant.lproj/Localizable.strings
+++ b/Natives/resources/zh-Hant.lproj/Localizable.strings
@@ -156,7 +156,7 @@
 
 "preference.title.renderer" = "渲染器";
 
-"preference.title.renderer.debug.auto" = "自動：gl4es或ANGLE";
+"preference.title.renderer.debug.auto" = "自動：ANGLE";
 "preference.title.renderer.debug.gl4es" = "gl4es 1.1.4 － 輸出OpenGL 2.1";
 "preference.title.renderer.debug.angle" = "ANGLE（1.17+）— 輸出OpenGL 3.2（核心，有限）";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 25.0.7) － 輸出OpenGL 4.1";

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A premium Minecraft: Java Edition launcher for iOS and iPadOS, rebuilt from the 
 - **Complete Chinese Localization** -- Fully translated interface with native-quality Chinese language support.
 - **Unrestricted Accounts** -- Local accounts, demo mode, and third-party authentication all supported; no Microsoft account required to download and play.
 - **Multi-Account** -- Seamlessly switch between Microsoft, local, and third-party authentication accounts.
-- **Auto Renderer Selection** -- Automatically chooses the optimal rendering backend (including MobileGlues, MoltenVK, and more) when set to Auto.
+- **Safe Auto Renderer** -- Auto currently resolves to ANGLE for consistent Minecraft 26.2+ compatibility. Choose MobileGlues, GL4ES, Zink, or MoltenVK explicitly when needed.
 - **Auto JVM Selection** -- Automatically selects the correct JVM version (Java 8, 17, 21, or 25) based on the game version.
 - **Minecraft 26.X Support** -- Experimental support for Minecraft 26.x.
 - **Custom Mouse Pointer** -- Customize the virtual mouse pointer skin in settings.

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,7 +44,7 @@
 - **完整中文本地化** -- 界面完整汉化，提供原生级中文语言体验。
 - **账户限制解除** -- 支持本地账户、演示模式和第三方认证，无需 Microsoft 账户即可下载和游玩。
 - **多账户支持** -- 在 Microsoft 账户、本地账户和第三方认证账户之间无缝切换。
-- **自动渲染器选择** -- 设为 Auto 时自动选择最优渲染后端（含 MobileGlues、MoltenVK 等渲染器）。
+- **安全的自动渲染器** -- Auto 当前固定解析为 ANGLE，以兼容 Minecraft 26.2+；如需 MobileGlues、GL4ES、Zink 或 MoltenVK，请手动明确选择。
 - **适配 Minecraft 26.X** -- 添加 Minecraft 26.X 支持（实验性）
 - **自定义鼠标指针** -- 在设置中自定义虚拟鼠标指针皮肤。
 - **TouchController 支持** -- 通过 UDP 和 XCFramework 两种通信方式与 TouchController Mod 通信，为 iOS 提供完整的触屏控制。

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -1,0 +1,190 @@
+"""Fast regression checks for renderer and resource-download wiring.
+
+These tests intentionally inspect source contracts so they can run on Windows without Xcode.
+The macOS CI build remains responsible for Objective-C compilation.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def source(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+class RendererContracts(unittest.TestCase):
+    def test_auto_has_one_canonical_resolution(self) -> None:
+        preferences = source("Natives/LauncherPreferences.m")
+        self.assertIn("NSString *PLResolveRendererKey", preferences)
+        self.assertRegex(
+            preferences,
+            r'isEqualToString:@"auto"\]\s*\?\s*@\s*RENDERER_NAME_MTL_ANGLE',
+        )
+        self.assertIn("PLResolveRendererKey(selectedRenderer)", source("Natives/JavaLauncher.m"))
+        self.assertIn(
+            'PLResolveRendererKey(NSProcessInfo.processInfo.environment[@"AMETHYST_RENDERER"])',
+            source("Natives/egl_bridge.m"),
+        )
+
+    def test_profile_default_is_distinct_from_explicit_auto(self) -> None:
+        settings = source("Natives/ProfileSettingsViewController.m")
+        self.assertIn("[(NSString *)profileRenderer length] > 0", settings)
+        self.assertIn("[(NSString *)profileGraphicsApi length] > 0", settings)
+        self.assertIn('[existing removeObjectForKey:@"renderer"]', settings)
+        self.assertIn("PLNormalizeRendererKey(self.selectedRenderer)", settings)
+
+    def test_launch_panels_do_not_overwrite_global_renderer(self) -> None:
+        for relative in (
+            "Natives/LauncherRightPanelViewController.m",
+            "Natives/VersionManagerViewController.m",
+        ):
+            text = source(relative)
+            self.assertNotRegex(text, r'setPrefString\(@"video\.(renderer|graphics_api)"')
+
+
+class ResourceContracts(unittest.TestCase):
+    SERVICES = (
+        "ModService",
+        "ShaderService",
+        "ResourcePackService",
+        "DataPackService",
+        "WorldService",
+    )
+
+    def test_download_source_reaches_version_request(self) -> None:
+        download = source("Natives/DownloadViewController.m")
+        self.assertIn("initialSource = modItem.apiSource", download)
+        self.assertIn("initialSource = shaderItem.apiSource", download)
+        self.assertIn("apiSource = item.apiSource", download)
+        asset_versions = source("Natives/AssetVersionViewController.m")
+        self.assertIn("if (self.apiSource == 2)", asset_versions)
+        self.assertIn("[CurseForgeAPI sharedInstance]", asset_versions)
+
+    def test_download_target_profile_is_preserved(self) -> None:
+        header = source("Natives/DownloadViewController.h")
+        implementation = source("Natives/DownloadViewController.m")
+        self.assertIn("targetProfileName", header)
+        self.assertGreaterEqual(implementation.count("[self effectiveTargetProfileName]"), 7)
+
+        expected_tabs = {
+            "Mods": 1,
+            "Shaders": 2,
+            "ResourcePacks": 3,
+            "DataPacks": 4,
+            "Worlds": 6,
+        }
+        for manager, tab in expected_tabs.items():
+            text = source(f"Natives/{manager}ManagerViewController.m")
+            self.assertRegex(text, rf"(?:downloadVC|vc)\.initialTabIndex = {tab};")
+            self.assertRegex(
+                text, r"(?:downloadVC|vc)\.targetProfileName = self\.profileName;"
+            )
+
+    def test_resource_services_publish_terminal_completion(self) -> None:
+        for service in self.SERVICES:
+            text = source(f"Natives/{service}.m")
+            self.assertIn("completedWithError:", text)
+            self.assertNotRegex(
+                text,
+                r'setTaskWithId:[^;]+state:DownloadTaskState(?:Completed|Failed)',
+            )
+
+    def test_paths_use_the_shared_profile_resolver(self) -> None:
+        for service in self.SERVICES:
+            text = source(f"Natives/{service}.m")
+            self.assertIn("resolvedGameDirectoryForProfileName", text)
+
+    def test_completed_transfer_is_not_shown_as_downloading_100_percent(self) -> None:
+        manager = source("Natives/DownloadTaskManager.m")
+        task_ui = source("Natives/DownloadTasksViewController.m")
+        detail_ui = source("Natives/PLTaskProgressViewController.m")
+        self.assertIn("item.progress = transferComplete ? 0.99 : progress", manager)
+        self.assertIn("stage.progress = transferComplete ? 0.99 : progress", manager)
+        self.assertIn("DownloadTaskUserInfoTransferCompleteKey", task_ui)
+        self.assertIn("DownloadTaskUserInfoTransferCompleteKey", detail_ui)
+        self.assertIn("PLDownloadTaskStateIsTerminal(oldState)", manager)
+        self.assertIn("floor(clamped * 1000.0)", task_ui)
+        self.assertIn("MIN(99", detail_ui)
+
+    def test_immediate_cache_hit_cannot_be_written_back_to_downloading(self) -> None:
+        manager = source("Natives/DownloadTaskManager.m")
+        self.assertIn("PLDownloadTaskStateIsTerminal(item.state)", manager)
+        for service in self.SERVICES[:-1]:
+            text = source(f"Natives/{service}.m")
+            start = text.index("startRequest:request")
+            mark_downloading = text.index("state:DownloadTaskStateDownloading", start)
+            unlock_after_registration = text.index(
+                "[self.downloadStateLock unlock]", mark_downloading
+            )
+            self.assertGreater(unlock_after_registration, mark_downloading)
+
+    def test_retry_cannot_rebuild_an_active_task_twice(self) -> None:
+        manager = source("Natives/DownloadTaskManager.m")
+        retry_method = manager[manager.index("- (void)retryTaskWithId:") :]
+        state_guard = retry_method.index("item.state != DownloadTaskStateFailed")
+        reset_pending = retry_method.index("item.state = DownloadTaskStatePending")
+        self.assertLess(state_guard, reset_pending)
+        self.assertIn("item.state != DownloadTaskStateCancelled", retry_method)
+        self.assertIn("item.state != DownloadTaskStatePaused", retry_method)
+
+    def test_paused_weak_raw_task_can_be_recreated(self) -> None:
+        manager = source("Natives/DownloadTaskManager.m")
+        resume_method = manager[
+            manager.index("- (void)resumeTaskWithId:") : manager.index(
+                "- (void)cancelTaskWithId:"
+            )
+        ]
+        self.assertIn(
+            "!rawTask && state == DownloadTaskStatePaused && item.retryHandler",
+            resume_method,
+        )
+        self.assertIn("[self retryTaskWithId:taskId]", resume_method)
+
+    def test_mod_and_shader_pagination_state_is_independent(self) -> None:
+        download = source("Natives/DownloadViewController.m")
+        self.assertNotIn("isLoadingMore", download)
+        self.assertNotIn("currentSearchQuery", download)
+        for token in (
+            "isLoadingMods",
+            "isLoadingShaders",
+            "modRequestGeneration",
+            "shaderRequestGeneration",
+            "modSearchQuery",
+            "shaderSearchQuery",
+        ):
+            self.assertIn(token, download)
+        self.assertIn("case 1: [self refreshModList]", download)
+        self.assertIn("case 2: [self refreshShaderList]", download)
+
+    def test_world_archive_must_contain_a_directly_visible_world(self) -> None:
+        world = source("Natives/WorldService.m")
+        self.assertIn("worldDirectoryContainingLevelDatUnderPath", world)
+        self.assertIn("level.dat is missing", world)
+        self.assertIn("BOOL finalWorldDirExistedBefore = NO", world)
+        self.assertIn("PLWorldDownloadGenerationKey", world)
+        self.assertIn("taskItem.maxRetryCount = 0", world)
+        self.assertIn("newTask.taskDescription = capturedTaskDescription", world)
+        self.assertIn("taskItemRef.rawTask = newTask", world)
+        self.assertIn("PLTaskStagesWorld()", world)
+
+    def test_world_pause_and_cancel_do_not_report_failure_or_success(self) -> None:
+        world = source("Natives/WorldService.m")
+        self.assertIn("error.code == NSURLErrorCancelled", world)
+        self.assertIn("if (isCancellation)", world)
+        self.assertIn(
+            "latestTask.state != DownloadTaskStateDownloading",
+            world,
+        )
+        self.assertIn(
+            "![latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation]",
+            world,
+        )
+        self.assertIn("[manager retryTaskWithId:taskItem.taskId]", world)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -31,11 +31,42 @@ class RendererContracts(unittest.TestCase):
         )
 
     def test_profile_default_is_distinct_from_explicit_auto(self) -> None:
+        preferences = source("Natives/LauncherPreferences.m")
         settings = source("Natives/ProfileSettingsViewController.m")
+        self.assertIn("NSString * const PLProfileInheritedValue", preferences)
+        self.assertIn("PLProfileInheritedDisplayName()", preferences)
         self.assertIn("[(NSString *)profileRenderer length] > 0", settings)
         self.assertIn("[(NSString *)profileGraphicsApi length] > 0", settings)
         self.assertIn('[existing removeObjectForKey:@"renderer"]', settings)
+        self.assertIn('[existing removeObjectForKey:@"graphicsApi"]', settings)
         self.assertIn("PLNormalizeRendererKey(self.selectedRenderer)", settings)
+        self.assertNotIn(
+            '[self.selectedRenderer isEqualToString:@"(default)"]', settings
+        )
+        self.assertNotIn(
+            '[self.selectedGraphicsApi isEqualToString:@"(default)"]', settings
+        )
+
+    def test_graphics_api_has_whitelist_normalization(self) -> None:
+        preferences = source("Natives/LauncherPreferences.m")
+        profiles = source("Natives/PLProfiles.m")
+        settings = source("Natives/ProfileSettingsViewController.m")
+        self.assertIn("NSString *PLNormalizeGraphicsApiKey", preferences)
+        self.assertIn("![getGraphicsApiKeys(NO) containsObject:key]", preferences)
+        self.assertGreaterEqual(profiles.count("PLNormalizeGraphicsApiKey"), 2)
+        self.assertGreaterEqual(settings.count("PLNormalizeGraphicsApiKey"), 2)
+
+    def test_explicit_unknown_target_profile_does_not_fall_back(self) -> None:
+        profiles = source("Natives/PLProfiles.m")
+        resolver = profiles[
+            profiles.index("+ (nullable NSString *)effectiveProfileNameForPreferredName:") :
+            profiles.index("- (id)initWithCurrentInstance")
+        ]
+        self.assertIn("if (preferredName.length > 0)", resolver)
+        self.assertIn("? preferredName : nil", resolver)
+        self.assertIn("if (effectiveName.length == 0) return nil", resolver)
+        self.assertIn("if (!baseDirectory.isAbsolutePath) return nil", resolver)
+        self.assertIn("![resolvedPath hasPrefix:basePrefix]", resolver)
 
     def test_launch_panels_do_not_overwrite_global_renderer(self) -> None:
         for relative in (
@@ -97,6 +128,57 @@ class ResourceContracts(unittest.TestCase):
         for service in self.SERVICES:
             text = source(f"Natives/{service}.m")
             self.assertIn("resolvedGameDirectoryForProfileName", text)
+
+        self.assertIn(
+            "if (gameDir.length == 0) return nil",
+            source("Natives/ResourcePackService.m"),
+        )
+        self.assertIn(
+            "if (gameDir.length == 0) return nil",
+            source("Natives/WorldService.m"),
+        )
+
+    def test_profile_aware_service_headers_accept_an_unspecified_target(self) -> None:
+        for service in self.SERVICES:
+            header = source(f"Natives/{service}.h")
+            self.assertIn("NSString * _Nullable)profileName", header)
+        profiles = source("Natives/PLProfiles.h")
+        self.assertIn("effectiveProfileNameForPreferredName:(nullable NSString *)", profiles)
+        self.assertIn("resolvedGameDirectoryForProfileName:(nullable NSString *)", profiles)
+
+    def test_explicit_invalid_profile_never_falls_back_to_shared_game_dir(self) -> None:
+        for service_name, existing_method, ensure_method in (
+            ("ModService", "existingModsFolderForProfile", "ensureModsFolderForProfile"),
+            (
+                "ShaderService",
+                "existingShadersFolderForProfile",
+                "ensureShadersFolderForProfile",
+            ),
+        ):
+            text = source(f"Natives/{service_name}.m")
+            start = text.index(f"- (nullable NSString *){existing_method}")
+            end = text.index("#pragma mark", start)
+            folder_methods = text[start:end]
+            self.assertIn("resolvedGameDir.length == 0", folder_methods)
+            self.assertIn(ensure_method, folder_methods)
+            self.assertNotIn('getenv("POJAV_GAME_DIR")', folder_methods)
+
+        resource_pack = source("Natives/ResourcePackService.m")
+        download = resource_pack[
+            resource_pack.index("- (void)downloadResourcePack:") :
+            resource_pack.index("#pragma mark - PLDownloadClient", resource_pack.index("- (void)downloadResourcePack:"))
+        ]
+        self.assertIn("ensureResourcePacksFolderForProfile:profileName", download)
+        self.assertNotIn("PLProfiles.current.profiles", download)
+        self.assertNotIn('getenv("POJAV_GAME_DIR")', download)
+
+        shader = source("Natives/ShaderService.m")
+        shader_download = shader[
+            shader.index("- (void)downloadShader:") :
+            shader.index("#pragma mark - PLDownloadClient", shader.index("- (void)downloadShader:"))
+        ]
+        self.assertIn("ensureShadersFolderForProfile:profileName", shader_download)
+        self.assertNotIn('profileName.length ? profileName : @"default"', shader_download)
 
     def test_completed_transfer_is_not_shown_as_downloading_100_percent(self) -> None:
         manager = source("Natives/DownloadTaskManager.m")
@@ -160,14 +242,47 @@ class ResourceContracts(unittest.TestCase):
         self.assertIn("case 1: [self refreshModList]", download)
         self.assertIn("case 2: [self refreshShaderList]", download)
 
-    def test_world_archive_must_contain_a_directly_visible_world(self) -> None:
+    def test_world_archive_is_staged_and_never_extracted_into_saves(self) -> None:
+        world = source("Natives/WorldService.m")
+        self.assertIn('PLWorldStagingRootName = @".amethyst-world-staging"', world)
+        self.assertGreaterEqual(
+            world.count("createWorldStagingDirectoryForSavesDir"), 4
+        )
+        self.assertIn("downloadStagingDirectories", world)
+        stage_method = world[
+            world.index("- (nullable PLStagedWorld *)stageWorldZipAt:") :
+            world.index("- (nullable NSString *)commitStagedWorld:")
+        ]
+        self.assertIn("extractFilesTo:extractDirectory overwrite:NO", stage_method)
+        self.assertNotIn("overwrite:YES", world)
+        self.assertNotIn("extractFilesTo:savesDir", world)
+        self.assertIn("archiveEntries:entries areSafeUnderDirectory", stage_method)
+
+        commit_method = world[
+            world.index("- (nullable NSString *)commitStagedWorld:") :
+            world.index("- (BOOL)isWorldTaskItemCurrent:")
+        ]
+        self.assertIn("if ([fm fileExistsAtPath:destination]) continue", commit_method)
+        self.assertIn("moveItemAtPath:source toPath:destination", commit_method)
+        self.assertIn('stringWithFormat:@"%@_%ld"', commit_method)
+        move = commit_method.index("moveItemAtPath:source toPath:destination")
+        rollback = commit_method.index("removeItemAtPath:destination")
+        self.assertLess(move, rollback)
+
+    def test_world_archive_requires_one_safe_visible_world(self) -> None:
         world = source("Natives/WorldService.m")
         self.assertIn("worldDirectoryContainingLevelDatUnderPath", world)
         self.assertIn("level.dat is missing", world)
-        self.assertIn("BOOL finalWorldDirExistedBefore = NO", world)
+        self.assertIn("multiple ambiguous worlds", world)
+        self.assertIn("NSFileTypeSymbolicLink", world)
+        self.assertIn("NSFileTypeRegular", world)
+        self.assertIn("sanitizedWorldDirectoryName", world)
         self.assertIn("PLWorldDownloadGenerationKey", world)
         self.assertIn("taskItem.maxRetryCount = 0", world)
-        self.assertIn("newTask.taskDescription = capturedTaskDescription", world)
+        self.assertIn("downloadWorldNames[newTask] = capturedWorldName", world)
+        self.assertIn("downloadSavesFolders[newTask] = capturedSavesFolder", world)
+        self.assertNotIn("task.taskDescription", world)
+        self.assertNotIn("componentsSeparatedByString:@\"\\n\"", world)
         self.assertIn("taskItemRef.rawTask = newTask", world)
         self.assertIn("PLTaskStagesWorld()", world)
 
@@ -175,15 +290,38 @@ class ResourceContracts(unittest.TestCase):
         world = source("Natives/WorldService.m")
         self.assertIn("error.code == NSURLErrorCancelled", world)
         self.assertIn("if (isCancellation)", world)
+        current_guard = world[
+            world.index("- (BOOL)isWorldTaskItemCurrent:") :
+            world.index("#pragma mark - 在线世界下载")
+        ]
+        self.assertIn("latestTask.state == DownloadTaskStateDownloading", current_guard)
         self.assertIn(
-            "latestTask.state != DownloadTaskStateDownloading",
-            world,
+            "[latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation]",
+            current_guard,
         )
-        self.assertIn(
-            "![latestTask.userInfo[PLWorldDownloadGenerationKey] isEqual:generation]",
-            world,
-        )
+        self.assertGreaterEqual(world.count("isWorldTaskItemCurrent"), 7)
+        online_finish = world[world.index("didFinishDownloadingToURL:") :]
+        commit = online_finish.index("commitStagedWorld:stagedWorld")
+        gate = online_finish.rfind("isWorldTaskItemCurrent", 0, commit)
+        main_queue = online_finish.rfind("dispatch_get_main_queue()", 0, commit)
+        self.assertGreaterEqual(gate, 0)
+        self.assertGreaterEqual(main_queue, 0)
+        self.assertLess(main_queue, gate)
+        self.assertIn("taskItem.supportsResume = NO", world)
+        self.assertIn("taskItemRef.supportsResume = YES", world)
+        self.assertIn("[fm removeItemAtPath:installedWorldPath error:nil]", world)
         self.assertIn("[manager retryTaskWithId:taskItem.taskId]", world)
+
+    def test_local_world_import_reports_100_only_after_safe_commit(self) -> None:
+        world = source("Natives/WorldService.m")
+        import_method = world[
+            world.index("- (void)importWorldFromURL:") :
+            world.index("#pragma mark - NSURLSessionDownloadDelegate")
+        ]
+        commit = import_method.index("commitStagedWorld:stagedWorld")
+        completed = import_method.index("prog.completedUnitCount = 1")
+        self.assertLess(commit, completed)
+        self.assertIn("cleanupWorldStagingDirectory:stagingDirectory", import_method)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

- 统一 renderer 与 graphicsApi 的白名单规范化和解析入口；Profile 空值继承全局设置，显式 Auto 与“继承默认”分离，启动一个 Profile 不再污染其他 Profile。
- JavaLauncher 与 EGL bridge 使用同一套 Auto 解析逻辑；当前 Auto 确定解析为 ANGLE，以保持 Minecraft 26.2+ 的稳定兼容。
- 保留 Modrinth / CurseForge API 来源，避免使用错误平台的项目 ID 请求版本。
- 将目标 Profile 贯穿资源管理页、下载页和落盘服务，统一解析 `.`、相对及绝对 gameDir；显式失效的 Profile 会明确失败，不再静默写入其他实例。
- 分离 Mod 与 Shader 的搜索、分页和请求代次状态，忽略过期响应，避免标签页之间互相阻塞或污染结果。
- 下载完成后主动刷新模组、光影、资源包、数据包和世界列表，使已落盘资源立即可见。
- 加固下载任务的终态、缓存命中、迟到回调、暂停/继续与重复重试；传输完成但仍在校验、落盘或解压时显示“处理中”及最高 99%，仅真正完成后显示 100%。
- 世界下载改为“下载 → staging 解压/验证 → 无冲突移动”流程：拒绝路径逃逸、符号链接和歧义世界，校验普通文件 `level.dat`，不覆盖或合并已有同名存档，并用 generation gate 隔离旧回调。
- 补充 renderer、目标 Profile、资源下载状态和世界安装链路的跨平台源码契约测试，并同步相关文档与本地化文案。

## 测试

- [x] `python -B -m unittest tests.test_source_contracts -v` — 20/20 通过
- [x] `git diff --check origin/main...HEAD` — 通过
- [x] 与最新 `origin/main` 比较，可自动合并
- [ ] macOS / Xcode 完整 Objective-C 构建
- [ ] iOS 真机验证 Auto、ANGLE、MobileGlues、GL4ES 与 Vulkan
- [ ] Modrinth / CurseForge 各资源类型端到端下载
- [ ] 世界 ZIP 实体样本与暂停、取消、重试竞态验证

## 已知限制

- 当前验证环境为 Windows，无法执行 Xcode/iOS 构建。
- UZKArchive 的实际解压过程不能中途终止；取消会阻止内容进入 `saves` 并在解压结束后清理 staging，但 App 在解压期间被强制结束时可能遗留隐藏 staging 目录。

Closes #121